### PR TITLE
Enable parsing of loaded Dataframes. Improve function naming.

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,7 +8,7 @@ version: 2
 build:
   os: ubuntu-20.04
   tools:
-    python: "3.12"
+    python: "3.13"
 
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:

--- a/README.md
+++ b/README.md
@@ -753,18 +753,18 @@ edge_types  = types.all.edges()
 OntoWeaver provides a way to parallelize the extraction of nodes and edges from the provided database, with the aim of
 reducing the runtime of the extraction process. By default, the parallel processing is disabled, and the data frame
 is processed in a sequential manner. To enable parallel processing, the user can pass the maximum number of workers to 
-the `extract_all` function. 
+the `extract_table` function. 
 
 For example, to enable parallel processing with 16 workers, the user can call the function as follows:
 
 ```python
-adapter = ontoweaver.tabular.extract_all(table, mapping, parallel_mapping = 16)
+adapter = ontoweaver.tabular.extract_table(table, mapping, parallel_mapping = 16)
 ```
 
 To enable parallel processing with a good default working on any machine, you can use the [approach suggested by the concurrent module](https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.ThreadPoolExecutor).
 ```python
 import os
-adapter = ontoweaver.tabular.extract_all(table, mapping, parallel_mapping = min(32, (os.process_cpu_count() or 1) + 4))
+adapter = ontoweaver.tabular.extract_table(table, mapping, parallel_mapping = min(32, (os.process_cpu_count() or 1) + 4))
 ```
 
 ## Information Fusion
@@ -795,8 +795,8 @@ The generic workflow is to first produce nodes and edges —as usual—
 then call the `fusion.reconciliate` function on the produced nodes and edges:
 ```python
 # Call the mappings:
-adapter_A = ontoweaver.tabular.extract_all(input_table_A, mapping_A)
-adapter_B = ontoweaver.tabular.extract_all(input_table_B, mapping_B)
+adapter_A = ontoweaver.tabular.extract_table(input_table_A, mapping_A)
+adapter_B = ontoweaver.tabular.extract_table(input_table_B, mapping_B)
 
 # Aggregate the nodes and edges:
 nodes = adapter_A.nodes + adapter_B.nodes

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -150,7 +150,7 @@ options:
 
 .. code:: sh
 
-   ontoweave --config biocypher_config.yaml --schema schema_config.yaml data-1.1.csv:map-1.yaml data-1.2.csv:map-1.yaml data-A.csv:map-A.yaml
+   ontoweave --biocypher-config biocypher_config.yaml --biocypher-schema schema_config.yaml data-1.1.csv:map-1.yaml data-1.2.csv:map-1.yaml data-A.csv:map-A.yaml
 
 note that you can use the same mapping on several data files, and/or
 several mappings.

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -11,7 +11,7 @@ OntoWeaver allows writing a simple declarative mapping to express how
 columns from a `Pandas <https://pandas.pydata.org/>`__ table are to be
 converted as typed nodes or edges in an SKG.
 
-.. image:: docs/OntoWeaver_logo__big.svg
+|image1|
 
 It provides a simple layer of abstraction on top of
 `Biocypher <https://biocypher.org>`__, which remains responsible for
@@ -128,74 +128,53 @@ populate the configured database. By default, the output script file is
 saved in a subdirectory of ``./biocypher-out/``, which name is a
 timestamp from when the adapter has been executed.
 
-To actually insert data in an SKG database, you will have to use
-Biocypher export API:
+To configure your data mapping, you will have to first define the
+mapping that you want to apply on your data. Then, you will need a
+BioCypher configuration file (which mainly indiciate your ontologoy and
+backend), and a schema configuration file (indicating which node and
+edge types you want).
 
-.. code:: python
+To actually do something, you need to run OntoWeaver mapping onto your
+data. We provide a command line interface to do so, called
+``ontoweave``.
 
-       import yaml
-       import pandas as pd
-       import biocypher
-       import ontoweaver
+If you use some default config file (usually ``biocypher_config.yaml``)
+and schema (usually ``schema_config.yaml``), the simplest call would be:
 
-       # Load ontology
-       bc = biocypher.BioCypher(
-           biocypher_config_path = "tests/simplest/biocypher_config.yaml",
-           schema_config_path = "tests/simplest/schema_config.yaml"
-       )
+.. code:: sh
 
-       # Load data
-       table = pd.read_csv("tests/simplest/data.csv")
+   ontoweave my_data.csv:my_mapping.yaml
 
-       # Load mapping
-       with open("tests/simplest/mapping.yaml") as fd:
-           mapping = yaml.full_load(fd)
+If you want to indicate your own configuration files, pass their name as
+options:
 
-       # Run the adapter
-       adapter = ontoweaver.tabular.extract_all(table, mapping)
+.. code:: sh
 
-       # Write nodes
-       bc.write_nodes( adapter.nodes )
+   ontoweave --config biocypher_config.yaml --schema schema_config.yaml data-1.1.csv:map-1.yaml data-1.2.csv:map-1.yaml data-A.csv:map-A.yaml
 
-       # Write edges
-       bc.write_edges( adapter.edges )
+note that you can use the same mapping on several data files, and/or
+several mappings.
 
-       # Write import script
-       bc.write_import_call()
+To actually insert data in an SKG database, you need to run the import
+files that are prepared by the previous command. Either you ask
+*ontoweave* to run it for you:
 
-       # Now you have a script that you can run to actually insert data.
+.. code:: sh
 
-Additionally, you will have to define a strategy for the naming of
-mapped items when creating nodes, by defining an ``affix`` and
-``separator`` to be used during node creation. The ``affix`` used will
-represent the ontology type of the item in question. Unless otherwise
-defined, the ``affix`` defaults to ``suffix`` and ``separator`` defaults
-to ``:``. This can be modified by changing the variables in the
-``extract_all()`` function. ``Affix`` can be either a ``prefix``,
-``suffix`` or ``none`` - in case you decide not to include the ontology
-type in the node naming strategy. Special care should be exercised in
-case there are several types of the same name in the database. There is
-a possibility that nodes of the same name will be merged together during
-mapping, so an ``affix`` should be present. Below are some examples of
-node naming strategies. ``NAME`` refers to the name of the item in
-question in your database, and ``TYPE`` refers to the type of the item
-in the ontology.
+   ontoweave my_data.csv:my_mapping.yaml --import-script-run
 
-.. code:: python
+or you can capture the import script path and run it yourself:
 
-   [...]
+.. code:: sh
 
-      # Affix defaults to "suffix", and separator defaults to ":"
-      # Node represented as [NAME]:[TYPE]
-      adapter = ontoweaver.tabular.extract_all(table, mapping)
+   script=$(ontoweave my_data.csv:my_mapping.yaml) # Capture.
+   $script # Run.
 
-      # Node represented as [TYPE]-[NAME]
-      adapter = ontoweaver.tabular.extract_all(table, mapping, affix = "prefix", separator = "-")
+You will find more options by running the help command:
 
-      # Node represented as [NAME]
-      adapter = ontoweaver.tabular.extract_all(table, mapping, affix = "none")
+.. code:: sh
 
-   [...]
+   ontoweave --help
 
 Mapping API
 -----------
@@ -205,9 +184,9 @@ of a mapping from a table to ontology types. As such, its core input is
 a dictionary, that takes the form of a YAML file. This configuration
 file indicates:
 
--  to which (node) type to map each line of the table,
--  to which (node) type to map columns of the table,
--  with which (edge) types to map relationships between nodes.
+- to which (node) type to map each line of the table,
+- to which (node) type to map columns of the table,
+- with which (edge) types to map relationships between nodes.
 
 The following explanations assume that you are familiar with
 `Biocypher’s
@@ -522,7 +501,7 @@ characters will be removed and substituted with an underscore, in case
 they are located inbetween allowed characters.
 
 By default, the transformer will allow alphanumeric characters (A-Z,
-a-z, 0-9), underscore (_), backtick (`), dot (.), and parentheses (),
+a-z, 0-9), underscore (\_), backtick (\`), dot (.), and parentheses (),
 and the substitute will be an empty string. If you wish to use the
 default settings, you can write:
 
@@ -637,13 +616,13 @@ the mapping configurations.
 
 Here is the list of available synonyms:
 
--  ``subject`` = ``row`` = ``entry`` = ``line`` = ``source``
--  ``column`` = ``columns`` = ``fields``
--  ``to_object`` = ``to_target`` = ``to_node``
--  ``from_subject`` = ``from_source``
--  ``via_relation`` = ``via_edge`` = ``via_predicate``
--  ``to_property`` = ``to_properties``
--  ``for_object`` = ``for_objects``
+- ``subject`` = ``row`` = ``entry`` = ``line`` = ``source``
+- ``column`` = ``columns`` = ``fields``
+- ``to_object`` = ``to_target`` = ``to_node``
+- ``from_subject`` = ``from_source``
+- ``via_relation`` = ``via_edge`` = ``via_predicate``
+- ``to_property`` = ``to_properties``
+- ``for_object`` = ``for_objects``
 
 How To
 ------
@@ -845,14 +824,14 @@ edges from the provided database, with the aim of reducing the runtime
 of the extraction process. By default, the parallel processing is
 disabled, and the data frame is processed in a sequential manner. To
 enable parallel processing, the user can pass the maximum number of
-workers to the ``extract_all`` function.
+workers to the ``extract_table`` function.
 
 For example, to enable parallel processing with 16 workers, the user can
 call the function as follows:
 
 .. code:: python
 
-   adapter = ontoweaver.tabular.extract_all(table, mapping, parallel_mapping = 16)
+   adapter = ontoweaver.tabular.extract_table(table, mapping, parallel_mapping = 16)
 
 To enable parallel processing with a good default working on any
 machine, you can use the `approach suggested by the concurrent
@@ -861,7 +840,7 @@ module <https://docs.python.org/3/library/concurrent.futures.html#concurrent.fut
 .. code:: python
 
    import os
-   adapter = ontoweaver.tabular.extract_all(table, mapping, parallel_mapping = min(32, (os.process_cpu_count() or 1) + 4))
+   adapter = ontoweaver.tabular.extract_table(table, mapping, parallel_mapping = min(32, (os.process_cpu_count() or 1) + 4))
 
 Information Fusion
 ------------------
@@ -896,8 +875,8 @@ edges:
 .. code:: python
 
    # Call the mappings:
-   adapter_A = ontoweaver.tabular.extract_all(input_table_A, mapping_A)
-   adapter_B = ontoweaver.tabular.extract_all(input_table_B, mapping_B)
+   adapter_A = ontoweaver.tabular.extract_table(input_table_A, mapping_A)
+   adapter_B = ontoweaver.tabular.extract_table(input_table_B, mapping_B)
 
    # Aggregate the nodes and edges:
    nodes = adapter_A.nodes + adapter_B.nodes
@@ -955,9 +934,9 @@ A node being composed of an identifier, a type label, and a properties
 dictionary, the ``serialize`` module provides function objects
 reflecting the useful combinations of those components:
 
--  ``ID`` (only the identifier)
--  ``IDLabel`` (the identifier and the type label)
--  ``All`` (the identifier, the type label, and the properties)
+- ``ID`` (only the identifier)
+- ``IDLabel`` (the identifier and the type label)
+- ``All`` (the identifier, the type label, and the properties)
 
 The user can instantiate those function objects, and pass them to the
 ``congregate`` module, to find which nodes are duplicates of each other.
@@ -974,27 +953,27 @@ For steps 2 to 4, OntoWeaver provides the ``merge`` module, which
 provides ways to merge two nodes’ components into a single one. It is
 separated into two submodules, depending on the type of the component:
 
--  ``string`` for components that are strings (i.e. identifier and type
-   label),
--  ``dictry`` for components that are dictionaries (i.e. properties).
+- ``string`` for components that are strings (i.e. identifier and type
+  label),
+- ``dictry`` for components that are dictionaries (i.e. properties).
 
 The ``string`` submodule provides:
 
--  ``UseKey``: replace the identifier with the serialization used at the
-   congregation step,
--  ``UseFirst``/``UseLast``: replace the type label with the first/last
-   one seen,
--  ``EnsureIdentical``: if two nodes’ components are not equal, raise an
-   error,
--  ``OrderedSet``: aggregate all the components of all the seen nodes
-   into a single, lexicographically ordered list (joined by a
-   user-defined separator).
+- ``UseKey``: replace the identifier with the serialization used at the
+  congregation step,
+- ``UseFirst``/``UseLast``: replace the type label with the first/last
+  one seen,
+- ``EnsureIdentical``: if two nodes’ components are not equal, raise an
+  error,
+- ``OrderedSet``: aggregate all the components of all the seen nodes
+  into a single, lexicographically ordered list (joined by a
+  user-defined separator).
 
 The ``dictry`` submodule provides:
 
--  ``Append``: merge all seen dictionaries in a single one, and
-   aggregate all the values of all the duplicated fields into a single
-   lexicographically ordered list (joined by a user-defined separator).
+- ``Append``: merge all seen dictionaries in a single one, and aggregate
+  all the values of all the duplicated fields into a single
+  lexicographically ordered list (joined by a user-defined separator).
 
 For example, to fuse “congregated” nodes, one can do:
 
@@ -1112,3 +1091,5 @@ deciding their type based on their properties), implement a
 If you need to decide how to fuse whole *sets* of duplicated nodes (for
 instance if you need to know all duplicated nodes before deciding which
 type to set), implement a ``fusion.Fusioner`` directly.
+
+.. |image1| image:: docs/OntoWeaver_logo__big.svg

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -11,7 +11,7 @@ OntoWeaver allows writing a simple declarative mapping to express how
 columns from a `Pandas <https://pandas.pydata.org/>`__ table are to be
 converted as typed nodes or edges in an SKG.
 
-|image1|
+|OntoWeaver logo|
 
 It provides a simple layer of abstraction on top of
 `Biocypher <https://biocypher.org>`__, which remains responsible for
@@ -1092,4 +1092,4 @@ If you need to decide how to fuse whole *sets* of duplicated nodes (for
 instance if you need to know all duplicated nodes before deciding which
 type to set), implement a ``fusion.Fusioner`` directly.
 
-.. |image1| image:: docs/OntoWeaver_logo__big.svg
+.. |OntoWeaver logo| image:: docs/OntoWeaver_logo__big.svg

--- a/docs/readme_sections/information_fusion.rst
+++ b/docs/readme_sections/information_fusion.rst
@@ -31,8 +31,8 @@ edges:
 .. code:: python
 
    # Call the mappings:
-   adapter_A = ontoweaver.tabular.extract_all(input_table_A, mapping_A)
-   adapter_B = ontoweaver.tabular.extract_all(input_table_B, mapping_B)
+   adapter_A = ontoweaver.tabular.extract_table(input_table_A, mapping_A)
+   adapter_B = ontoweaver.tabular.extract_table(input_table_B, mapping_B)
 
    # Aggregate the nodes and edges:
    nodes = adapter_A.nodes + adapter_B.nodes

--- a/docs/readme_sections/overview.rst
+++ b/docs/readme_sections/overview.rst
@@ -8,7 +8,7 @@ OntoWeaver allows writing a simple declarative mapping to express how
 columns from a `Pandas <https://pandas.pydata.org/>`__ table are to be
 converted as typed nodes or edges in an SKG.
 
-|image1|
+|OntoWeaver logo|
 
 It provides a simple layer of abstraction on top of
 `Biocypher <https://biocypher.org>`__, which remains responsible for
@@ -40,4 +40,5 @@ looking like:
        - source: "My OntoWeaver adapter"
        - version: "v1.2.3"
 
-.. |image1| image:: docs/OntoWeaver_logo__big.svg
+
+.. |OntoWeaver logo| image:: docs/OntoWeaver_logo__big.svg

--- a/docs/readme_sections/overview.rst
+++ b/docs/readme_sections/overview.rst
@@ -1,3 +1,5 @@
+Overview
+--------
 
 OntoWeaver is a tool for importing table data in Semantic Knowledge
 Graphs (SKG) databases.
@@ -5,6 +7,8 @@ Graphs (SKG) databases.
 OntoWeaver allows writing a simple declarative mapping to express how
 columns from a `Pandas <https://pandas.pydata.org/>`__ table are to be
 converted as typed nodes or edges in an SKG.
+
+|image1|
 
 It provides a simple layer of abstraction on top of
 `Biocypher <https://biocypher.org>`__, which remains responsible for
@@ -35,3 +39,5 @@ looking like:
    metadata: # Optional properties added to every node and edge.
        - source: "My OntoWeaver adapter"
        - version: "v1.2.3"
+
+.. |image1| image:: docs/OntoWeaver_logo__big.svg

--- a/docs/readme_sections/parallel_processing.rst
+++ b/docs/readme_sections/parallel_processing.rst
@@ -6,14 +6,14 @@ edges from the provided database, with the aim of reducing the runtime
 of the extraction process. By default, the parallel processing is
 disabled, and the data frame is processed in a sequential manner. To
 enable parallel processing, the user can pass the maximum number of
-workers to the ``extract_all`` function.
+workers to the ``extract_table`` function.
 
 For example, to enable parallel processing with 16 workers, the user can
 call the function as follows:
 
 .. code:: python
 
-   adapter = ontoweaver.tabular.extract_all(table, mapping, parallel_mapping = 16)
+   adapter = ontoweaver.tabular.extract_table(table, mapping, parallel_mapping = 16)
 
 To enable parallel processing with a good default working on any
 machine, you can use the `approach suggested by the concurrent
@@ -22,4 +22,4 @@ module <https://docs.python.org/3/library/concurrent.futures.html#concurrent.fut
 .. code:: python
 
    import os
-   adapter = ontoweaver.tabular.extract_all(table, mapping, parallel_mapping = min(32, (os.process_cpu_count() or 1) + 4))
+   adapter = ontoweaver.tabular.extract_table(table, mapping, parallel_mapping = min(32, (os.process_cpu_count() or 1) + 4))

--- a/docs/readme_sections/usage.rst
+++ b/docs/readme_sections/usage.rst
@@ -33,7 +33,7 @@ options:
 
 .. code:: sh
 
-   ontoweave --config biocypher_config.yaml --schema schema_config.yaml data-1.1.csv:map-1.yaml data-1.2.csv:map-1.yaml data-A.csv:map-A.yaml
+   ontoweave --biocypher-config biocypher_config.yaml --biocypher-schema schema_config.yaml data-1.1.csv:map-1.yaml data-1.2.csv:map-1.yaml data-A.csv:map-A.yaml
 
 note that you can use the same mapping on several data files, and/or
 several mappings.

--- a/docs/readme_sections/usage.rst
+++ b/docs/readme_sections/usage.rst
@@ -50,7 +50,7 @@ or you can capture the import script path and run it yourself:
 
 .. code:: sh
 
-   script=$(ontoweave my_data.csv:my_mapping.yaml) # Capture.
+   script="$(ontoweave my_data.csv:my_mapping.yaml)" # Capture.
    $script # Run.
 
 You will find more options by running the help command:

--- a/docs/readme_sections/usage.rst
+++ b/docs/readme_sections/usage.rst
@@ -11,71 +11,50 @@ populate the configured database. By default, the output script file is
 saved in a subdirectory of ``./biocypher-out/``, which name is a
 timestamp from when the adapter has been executed.
 
-To actually insert data in an SKG database, you will have to use
-Biocypher export API:
+To configure your data mapping, you will have to first define the
+mapping that you want to apply on your data. Then, you will need a
+BioCypher configuration file (which mainly indiciate your ontologoy and
+backend), and a schema configuration file (indicating which node and
+edge types you want).
 
-.. code:: python
+To actually do something, you need to run OntoWeaver mapping onto your
+data. We provide a command line interface to do so, called
+``ontoweave``.
 
-       import yaml
-       import pandas as pd
-       import biocypher
-       import ontoweaver
+If you use some default config file (usually ``biocypher_config.yaml``)
+and schema (usually ``schema_config.yaml``), the simplest call would be:
 
-       # Load ontology
-       bc = biocypher.BioCypher(
-           biocypher_config_path = "tests/simplest/biocypher_config.yaml",
-           schema_config_path = "tests/simplest/schema_config.yaml"
-       )
+.. code:: sh
 
-       # Load data
-       table = pd.read_csv("tests/simplest/data.csv")
+   ontoweave my_data.csv:my_mapping.yaml
 
-       # Load mapping
-       with open("tests/simplest/mapping.yaml") as fd:
-           mapping = yaml.full_load(fd)
+If you want to indicate your own configuration files, pass their name as
+options:
 
-       # Run the adapter
-       adapter = ontoweaver.tabular.extract_all(table, mapping)
+.. code:: sh
 
-       # Write nodes
-       bc.write_nodes( adapter.nodes )
+   ontoweave --config biocypher_config.yaml --schema schema_config.yaml data-1.1.csv:map-1.yaml data-1.2.csv:map-1.yaml data-A.csv:map-A.yaml
 
-       # Write edges
-       bc.write_edges( adapter.edges )
+note that you can use the same mapping on several data files, and/or
+several mappings.
 
-       # Write import script
-       bc.write_import_call()
+To actually insert data in an SKG database, you need to run the import
+files that are prepared by the previous command. Either you ask
+*ontoweave* to run it for you:
 
-       # Now you have a script that you can run to actually insert data.
+.. code:: sh
 
-Additionally, you will have to define a strategy for the naming of
-mapped items when creating nodes, by defining an ``affix`` and
-``separator`` to be used during node creation. The ``affix`` used will
-represent the ontology type of the item in question. Unless otherwise
-defined, the ``affix`` defaults to ``suffix`` and ``separator`` defaults
-to ``:``. This can be modified by changing the variables in the
-``extract_all()`` function. ``Affix`` can be either a ``prefix``,
-``suffix`` or ``none`` - in case you decide not to include the ontology
-type in the node naming strategy. Special care should be exercised in
-case there are several types of the same name in the database. There is
-a possibility that nodes of the same name will be merged together during
-mapping, so an ``affix`` should be present. Below are some examples of
-node naming strategies. ``NAME`` refers to the name of the item in
-question in your database, and ``TYPE`` refers to the type of the item
-in the ontology.
+   ontoweave my_data.csv:my_mapping.yaml --import-script-run
 
-.. code:: python
+or you can capture the import script path and run it yourself:
 
-   [...]
+.. code:: sh
 
-      # Affix defaults to "suffix", and separator defaults to ":"
-      # Node represented as [NAME]:[TYPE]
-      adapter = ontoweaver.tabular.extract_all(table, mapping)
+   script=$(ontoweave my_data.csv:my_mapping.yaml) # Capture.
+   $script # Run.
 
-      # Node represented as [TYPE]-[NAME]
-      adapter = ontoweaver.tabular.extract_all(table, mapping, affix = "prefix", separator = "-")
+You will find more options by running the help command:
 
-      # Node represented as [NAME]
-      adapter = ontoweaver.tabular.extract_all(table, mapping, affix = "none")
+.. code:: sh
 
-   [...]
+   ontoweave --help

--- a/src/ontoweaver/__init__.py
+++ b/src/ontoweaver/__init__.py
@@ -4,7 +4,6 @@ import biocypher
 import yaml
 import pandas as pd
 
-from test import adapter
 from . import base
 Node = base.Node
 Edge = base.Edge

--- a/src/ontoweaver/__init__.py
+++ b/src/ontoweaver/__init__.py
@@ -1,9 +1,8 @@
-from typing import Tuple, Optional
+from typing import Tuple
 
 import biocypher
 import yaml
 import pandas as pd
-from networkx.classes import nodes
 
 from . import base
 Node = base.Node

--- a/src/ontoweaver/__init__.py
+++ b/src/ontoweaver/__init__.py
@@ -4,6 +4,7 @@ import biocypher
 import yaml
 import pandas as pd
 
+from test import adapter
 from . import base
 Node = base.Node
 Edge = base.Edge
@@ -45,6 +46,7 @@ def extract_reconciliate_write(biocypher_config_path, schema_path, filename_to_m
    """
     nodes = []
     edges = []
+    adapter = None
 
     if filename_to_mapping:
 
@@ -59,9 +61,6 @@ def extract_reconciliate_write(biocypher_config_path, schema_path, filename_to_m
             adapter = tabular.extract_table(table, mapping, parallel_mapping=parallel_mapping, affix=affix,
                                             separator=affix_separator)
 
-            nodes += adapter.nodes
-            edges += adapter.edges
-
     if dataframe_to_mapping:
 
         assert(type(dataframe_to_mapping) == dict) # data_frame => yaml_object
@@ -71,8 +70,9 @@ def extract_reconciliate_write(biocypher_config_path, schema_path, filename_to_m
             adapter = tabular.extract_table(data_frame, yaml_object, parallel_mapping=parallel_mapping, affix=affix,
                                             separator=affix_separator)
 
-            nodes += adapter.nodes
-            edges += adapter.edges
+    if adapter:
+        nodes += adapter.nodes
+        edges += adapter.edges
 
     fnodes, fedges = fusion.reconciliate(nodes, edges, separator = separator)
 
@@ -107,6 +107,7 @@ def extract(filename_to_mapping = None, dataframe_to_mapping = None, parallel_ma
 
     nodes = []
     edges = []
+    adapter = None
 
     if filename_to_mapping:
 
@@ -121,8 +122,6 @@ def extract(filename_to_mapping = None, dataframe_to_mapping = None, parallel_ma
             adapter = tabular.extract_table(table, mapping, parallel_mapping=parallel_mapping, affix=affix,
                                             separator=affix_separator)
 
-            nodes += adapter.nodes
-            edges += adapter.edges
 
     if dataframe_to_mapping:
 
@@ -133,8 +132,9 @@ def extract(filename_to_mapping = None, dataframe_to_mapping = None, parallel_ma
             adapter = tabular.extract_table(data_frame, yaml_object, parallel_mapping=parallel_mapping, affix=affix,
                                             separator=affix_separator)
 
-            nodes += adapter.nodes
-            edges += adapter.edges
+    if adapter:
+        nodes += adapter.nodes
+        edges += adapter.edges
 
     return nodes, edges
 

--- a/src/ontoweaver/__init__.py
+++ b/src/ontoweaver/__init__.py
@@ -45,7 +45,6 @@ def extract_reconciliate_write(biocypher_config_path, schema_path, filename_to_m
    """
     nodes = []
     edges = []
-    adapter = None
 
     if filename_to_mapping:
 
@@ -60,6 +59,9 @@ def extract_reconciliate_write(biocypher_config_path, schema_path, filename_to_m
             adapter = tabular.extract_table(table, mapping, parallel_mapping=parallel_mapping, affix=affix,
                                             separator=affix_separator)
 
+            nodes += adapter.nodes
+            edges += adapter.edges
+
     if dataframe_to_mapping:
 
         assert(type(dataframe_to_mapping) == dict) # data_frame => yaml_object
@@ -69,9 +71,8 @@ def extract_reconciliate_write(biocypher_config_path, schema_path, filename_to_m
             adapter = tabular.extract_table(data_frame, yaml_object, parallel_mapping=parallel_mapping, affix=affix,
                                             separator=affix_separator)
 
-    if adapter:
-        nodes += adapter.nodes
-        edges += adapter.edges
+            nodes += adapter.nodes
+            edges += adapter.edges
 
     fnodes, fedges = fusion.reconciliate(nodes, edges, separator = separator)
 
@@ -106,7 +107,6 @@ def extract(filename_to_mapping = None, dataframe_to_mapping = None, parallel_ma
 
     nodes = []
     edges = []
-    adapter = None
 
     if filename_to_mapping:
 
@@ -121,6 +121,9 @@ def extract(filename_to_mapping = None, dataframe_to_mapping = None, parallel_ma
             adapter = tabular.extract_table(table, mapping, parallel_mapping=parallel_mapping, affix=affix,
                                             separator=affix_separator)
 
+            nodes += adapter.nodes
+            edges += adapter.edges
+
 
     if dataframe_to_mapping:
 
@@ -131,9 +134,8 @@ def extract(filename_to_mapping = None, dataframe_to_mapping = None, parallel_ma
             adapter = tabular.extract_table(data_frame, yaml_object, parallel_mapping=parallel_mapping, affix=affix,
                                             separator=affix_separator)
 
-    if adapter:
-        nodes += adapter.nodes
-        edges += adapter.edges
+            nodes += adapter.nodes
+            edges += adapter.edges
 
     return nodes, edges
 

--- a/src/ontoweaver/__init__.py
+++ b/src/ontoweaver/__init__.py
@@ -66,8 +66,10 @@ def extract_reconciliate_write(biocypher_config_path, schema_path, data_mappings
         schema_config_path = schema_path
     )
 
-    bc.write_nodes(fnodes)
-    bc.write_edges(fedges)
+    if fnodes:
+        bc.write_nodes(fnodes)
+    if fedges:
+        bc.write_edges(fedges)
     import_file = bc.write_import_call()
 
     return import_file

--- a/src/ontoweaver/__init__.py
+++ b/src/ontoweaver/__init__.py
@@ -24,7 +24,7 @@ from . import exceptions
 __all__ = ['Node', 'Edge', 'Transformer', 'Adapter', 'All', 'tabular', 'types', 'transformer', 'serialize', 'congregate', 'merge', 'fuse', 'fusion', 'exceptions']
 
 
-def extract_reconciliate_write(biocypher_config_path, schema_path, data_mappings = None, loaded_data_mappings = None, parallel_mapping = 0, separator = None, affix = "none", affix_separator = ":"):
+def extract_reconciliate_write(biocypher_config_path, schema_path, filename_to_mapping = None, dataframe_to_mapping = None, parallel_mapping = 0, separator = None, affix = "none", affix_separator = ":"):
     """Calls several mappings, each on the related Pandas-readable tabular data file,
        then reconciliate duplicated nodes and edges (on nodes' IDs, merging properties in lists),
        then export everything with BioCypher.
@@ -33,8 +33,8 @@ def extract_reconciliate_write(biocypher_config_path, schema_path, data_mappings
        Args:
            biocypher_config_path: the BioCypher configuration file.
            schema_path: the assembling schema file.
-           data_mappings: a dictionary mapping data file path to the OntoWeaver mapping yaml file to extract them.
-           loaded_data_mappings: a dictionary mapping loaded Pandas data frame to the  mapping yaml file.
+           filename_to_mapping: a dictionary mapping data file path to the OntoWeaver mapping yaml file to extract them.
+           dataframe_to_mapping: a dictionary mapping loaded Pandas data frame to the loaded yaml mapping object.
            parallel_mapping (int): Number of workers to use in parallel mapping. Defaults to 0 for sequential processing.
            separator (str, optional): The separator to use for combining values in reconciliation. Defaults to None.
            affix (str, optional): The affix to use for type inclusion. Defaults to "none".
@@ -46,11 +46,11 @@ def extract_reconciliate_write(biocypher_config_path, schema_path, data_mappings
     nodes = []
     edges = []
 
-    if data_mappings:
+    if filename_to_mapping:
 
-        assert(type(data_mappings) == dict) # data_file => mapping_file
+        assert(type(filename_to_mapping) == dict) # data_file => mapping_file
 
-        for data_file, mapping_file in data_mappings.items():
+        for data_file, mapping_file in filename_to_mapping.items():
             table = pd.read_csv(data_file)
 
             with open(mapping_file) as fd:
@@ -62,15 +62,13 @@ def extract_reconciliate_write(biocypher_config_path, schema_path, data_mappings
             nodes += adapter.nodes
             edges += adapter.edges
 
-    if loaded_data_mappings:
+    if dataframe_to_mapping:
 
-        assert(type(loaded_data_mappings) == dict) # data_frame => mapping_file
+        assert(type(dataframe_to_mapping) == dict) # data_frame => yaml_object
 
-        for data_frame, mapping_file in loaded_data_mappings.items():
-            with open(mapping_file) as fd:
-                mapping = yaml.full_load(fd)
+        for data_frame, yaml_object in dataframe_to_mapping.items():
 
-            adapter = tabular.extract_table(data_frame, mapping, parallel_mapping=parallel_mapping, affix=affix,
+            adapter = tabular.extract_table(data_frame, yaml_object, parallel_mapping=parallel_mapping, affix=affix,
                                             separator=affix_separator)
 
             nodes += adapter.nodes
@@ -92,13 +90,13 @@ def extract_reconciliate_write(biocypher_config_path, schema_path, data_mappings
     return import_file
 
 
-def extract(data_mappings = None, loaded_data_mappings = None, parallel_mapping = 0, affix="none", affix_separator=":") -> Tuple[list[Tuple], list[Tuple]]:
+def extract(filename_to_mapping = None, dataframe_to_mapping = None, parallel_mapping = 0, affix="none", affix_separator=":") -> Tuple[list[Tuple], list[Tuple]]:
     """
     Extracts nodes and edges from tabular data files based on provided mappings.
 
     Args:
-        data_mappings (dict): a dictionary mapping data file path to the OntoWeaver mapping yaml file to extract them.
-        loaded_data_mappings (dict): a dictionary mapping loaded Pandas data frame to the  mapping yaml file.
+        filename_to_mapping (dict): a dictionary mapping data file path to the OntoWeaver mapping yaml file to extract them.
+        dataframe_to_mapping: a dictionary mapping loaded Pandas data frame to the loaded yaml mapping object.
         parallel_mapping (int): Number of workers to use in parallel mapping. Defaults to 0 for sequential processing.
         affix (str, optional): The affix to use for type inclusion. Defaults to "none".
         affix_separator: The character(s) separating the label from its type affix. Defaults to ":".
@@ -110,11 +108,11 @@ def extract(data_mappings = None, loaded_data_mappings = None, parallel_mapping 
     nodes = []
     edges = []
 
-    if data_mappings:
+    if filename_to_mapping:
 
-        assert(type(data_mappings) == dict) # data_file => mapping_file
+        assert(type(filename_to_mapping) == dict) # data_file => mapping_file
 
-        for data_file, mapping_file in data_mappings.items():
+        for data_file, mapping_file in filename_to_mapping.items():
             table = pd.read_csv(data_file)
 
             with open(mapping_file) as fd:
@@ -126,15 +124,13 @@ def extract(data_mappings = None, loaded_data_mappings = None, parallel_mapping 
             nodes += adapter.nodes
             edges += adapter.edges
 
-    if loaded_data_mappings:
+    if dataframe_to_mapping:
 
-        assert(type(loaded_data_mappings) == dict) # data_frame => mapping_file
+        assert(type(dataframe_to_mapping) == dict) # data_frame => yaml_object
 
-        for data_frame, mapping_file in loaded_data_mappings.items():
-            with open(mapping_file) as fd:
-                mapping = yaml.full_load(fd)
+        for data_frame, yaml_object in dataframe_to_mapping.items():
 
-            adapter = tabular.extract_table(data_frame, mapping, parallel_mapping=parallel_mapping, affix=affix,
+            adapter = tabular.extract_table(data_frame, yaml_object, parallel_mapping=parallel_mapping, affix=affix,
                                             separator=affix_separator)
 
             nodes += adapter.nodes

--- a/src/ontoweaver/tabular.py
+++ b/src/ontoweaver/tabular.py
@@ -404,7 +404,7 @@ class PandasAdapter(base.Adapter):
                 f"Performed {nb_transformations} transformations with {len(self.transformers)} transformers, producing {nb_nodes} nodes for {nb_rows} rows.")
 
 
-def extract_all(df: pd.DataFrame, config: dict, parallel_mapping = 0, module = types, affix = "suffix", separator = ":"):
+def extract_table(df: pd.DataFrame, config: dict, parallel_mapping = 0, module = types, affix = "suffix", separator = ":"):
     """
     Proxy function for extracting from a table all nodes, edges and properties
     that are defined in a PandasAdapter configuration.

--- a/tests/test_2ontologies.py
+++ b/tests/test_2ontologies.py
@@ -18,7 +18,7 @@ def main():
     with open("oim.yaml") as fd:
         mapping = yaml.full_load(fd)
 
-    adapter = ontoweaver.tabular.extract_all(table, mapping)
+    adapter = ontoweaver.tabular.extract_table(table, mapping)
     assert(adapter)
 
     assert(adapter.nodes)

--- a/tests/test_affix_separator.py
+++ b/tests/test_affix_separator.py
@@ -29,7 +29,7 @@ def test_affix_separator():
 
     logging.debug("Run the adapter...")
 
-    adapter = ontoweaver.tabular.extract_all(table, mapping, affix="prefix", separator="___")
+    adapter = ontoweaver.tabular.extract_table(table, mapping, affix="prefix", separator="___")
 
     assert (adapter)
 

--- a/tests/test_edges_between_columns.py
+++ b/tests/test_edges_between_columns.py
@@ -31,7 +31,7 @@ def test_edges_between_columns():
 
     logging.debug("Run the adapter...")
 
-    adapter = ontoweaver.tabular.extract_all(table, mapping)
+    adapter = ontoweaver.tabular.extract_table(table, mapping)
 
     assert (adapter)
 

--- a/tests/test_multiple_databases.py
+++ b/tests/test_multiple_databases.py
@@ -34,7 +34,7 @@ def test_multiple_databases():
         mapping = yaml.full_load(fd)
 
     logging.debug("Run the adapter (CGI)...")
-    adapter_cgi = ontoweaver.tabular.extract_all(table, mapping)
+    adapter_cgi = ontoweaver.tabular.extract_table(table, mapping)
     assert (adapter_cgi)
 
     logging.debug("Add CGI nodes...")
@@ -55,7 +55,7 @@ def test_multiple_databases():
         mapping = yaml.full_load(fd)
 
     logging.debug("Run the adapter (OncoKB)...")
-    adapter_oncokb = ontoweaver.tabular.extract_all(table, mapping)
+    adapter_oncokb = ontoweaver.tabular.extract_table(table, mapping)
     assert (adapter_oncokb)
 
     time.sleep(1) # Sleep for 1 second to allow the previous csv outputs to be removed. Test otherwise fails because

--- a/tests/test_oncokb.py
+++ b/tests/test_oncokb.py
@@ -31,7 +31,7 @@ def test_oncokb():
     logging.debug("Run the adapter...")
     from tests.oncokb import types
 
-    adapter = ontoweaver.tabular.extract_all(table, mapping)
+    adapter = ontoweaver.tabular.extract_table(table, mapping)
 
     assert (adapter)
 

--- a/tests/test_ontology_subtypes.py
+++ b/tests/test_ontology_subtypes.py
@@ -29,7 +29,7 @@ def test_ontology_subtypes():
 
     logging.debug("Run the adapter...")
 
-    adapter = ontoweaver.tabular.extract_all(table, mapping)
+    adapter = ontoweaver.tabular.extract_table(table, mapping)
 
     assert (adapter)
 

--- a/tests/test_parallel_mapping.py
+++ b/tests/test_parallel_mapping.py
@@ -27,7 +27,7 @@ def test_parallel_mapping():
         mapping = yaml.full_load(fd)
 
     logging.debug("Run the adapter...")
-    adapter = ontoweaver.tabular.extract_all(table, mapping, parallel_mapping = 8)
+    adapter = ontoweaver.tabular.extract_table(table, mapping, parallel_mapping=8)
 
     assert (adapter)
 

--- a/tests/test_preprocessing_ontology/test_preprocessing_ontology.py
+++ b/tests/test_preprocessing_ontology/test_preprocessing_ontology.py
@@ -27,7 +27,7 @@ def main():
     with open("mapping.yaml") as fd:
         mapping = yaml.full_load(fd)
 
-    adapter = ontoweaver.tabular.extract_all(table, mapping)
+    adapter = ontoweaver.tabular.extract_table(table, mapping)
     assert(adapter)
 
     assert(adapter.nodes)

--- a/tests/test_properties_metadata.py
+++ b/tests/test_properties_metadata.py
@@ -27,7 +27,7 @@ def test_simplest():
 
     logging.debug("Run the adapter...")
 
-    adapter = ontoweaver.tabular.extract_all(table, mapping, affix="suffix")
+    adapter = ontoweaver.tabular.extract_table(table, mapping, affix="suffix")
 
     assert (adapter)
 

--- a/tests/test_replace.py
+++ b/tests/test_replace.py
@@ -31,7 +31,7 @@ def test_replace():
 
     logging.debug("Run the adapter...")
 
-    adapter = ontoweaver.tabular.extract_all(table, mapping, affix="prefix", separator="___")
+    adapter = ontoweaver.tabular.extract_table(table, mapping, affix="prefix", separator="___")
 
     time.sleep(1) # Sleep for 1 second to allow the previous csv outputs to be removed. Test otherwise fails because
                   # the directory contains the BioCypher output of previous tests.

--- a/tests/test_simplest.py
+++ b/tests/test_simplest.py
@@ -27,7 +27,7 @@ def test_simplest():
 
     logging.debug("Run the adapter...")
 
-    adapter = ontoweaver.tabular.extract_all(table, mapping, affix="none")
+    adapter = ontoweaver.tabular.extract_table(table, mapping, affix="none")
 
     assert (adapter)
 

--- a/tests/test_singular-plural.py
+++ b/tests/test_singular-plural.py
@@ -63,10 +63,10 @@ P2,V2-2,S3"""
 
 
     logging.debug("Run the plural adapter...")
-    plural_adapter = ontoweaver.tabular.extract_all(table, plural_map, affix="none")
+    plural_adapter = ontoweaver.tabular.extract_table(table, plural_map, affix="none")
 
     logging.debug("Run the singular adapter...")
-    singular_adapter = ontoweaver.tabular.extract_all(table, singular_map, affix="none")
+    singular_adapter = ontoweaver.tabular.extract_table(table, singular_map, affix="none")
 
     assert(list(plural_adapter.nodes) == list(singular_adapter.nodes))
     assert(list(plural_adapter.edges) == list(singular_adapter.edges))

--- a/tests/test_transformer-string.py
+++ b/tests/test_transformer-string.py
@@ -53,7 +53,7 @@ P2,V2-2,S3"""
     map = yaml.safe_load(mapping)
 
     logging.debug("Run the adapter...")
-    adapter = ontoweaver.tabular.extract_all(table, map, affix="none")
+    adapter = ontoweaver.tabular.extract_table(table, map, affix="none")
 
     for node in adapter.nodes:
         assert(node[2]["something"] == "Whatever it is")

--- a/tests/test_transformer_user.py
+++ b/tests/test_transformer_user.py
@@ -38,7 +38,7 @@ def test_transformer_user():
     table = pd.read_csv(csv_file)
 
     logging.debug("Run the adapter...")
-    adapter = ontoweaver.tabular.extract_all(table, mapping, affix="none")
+    adapter = ontoweaver.tabular.extract_table(table, mapping, affix="none")
 
 
 if __name__ == "__main__":

--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -32,7 +32,7 @@ def test_translate():
     table = pd.read_csv(csv_file)
 
     logging.debug("Run the adapter...")
-    adapter = ontoweaver.tabular.extract_all(table, mapping, affix="none")
+    adapter = ontoweaver.tabular.extract_table(table, mapping, affix="none")
 
     assert(adapter)
     assert(adapter.nodes)

--- a/tests/test_translate_file.py
+++ b/tests/test_translate_file.py
@@ -32,7 +32,7 @@ def test_translate_file():
     table = pd.read_csv(csv_file)
 
     logging.debug("Run the adapter...")
-    adapter = ontoweaver.tabular.extract_all(table, mapping, affix="none")
+    adapter = ontoweaver.tabular.extract_table(table, mapping, affix="none")
 
     assert(adapter)
     assert(adapter.nodes)


### PR DESCRIPTION
- Add option to pass `loaded data frame : mapping file` dictionary to extraction functions. 
- Update naming of said functions to better reflect their usage and update README and docstring.
- Update Read the Docs configuration to use Python13 and new function naming.
- TODO: After merging, usages of `extract` and `tabular.extract_all` functions should be renamed in `OncodashKB`.