### PR TITLE
Input and output data validation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ numpy = "^2.1.3"
 owlready2 = "^0.47"
 jsonargparse = "^4.35"
 xdg-base-dirs = "^6.0.2"
+pandera = { version = "^0.22.1", extras = ["io"] }
 
 [tool.poetry.dev-dependencies]
 pytest = "^8.3.4"

--- a/src/ontoweaver/__init__.py
+++ b/src/ontoweaver/__init__.py
@@ -164,11 +164,13 @@ def validate_only(data_mappings: dict):
             *mapping,
         )
 
-        if adapter:
-            try:
-                adapter.validator(table)
-                return True
-            except pa.errors.SchemaErrors as exc:
-                logging.info(exc.failure_cases)
-                return False
+        try:
+            adapter.validator(table)
+            return True
+        except pa.errors.SchemaErrors as exc:
+            logging.info(f"Validation failed for {exc.failure_cases}.")
+            return False
+        except Exception as e:
+            logging.error(f"An unexpected error occurred: {e}")
+            return False
 

--- a/src/ontoweaver/tabular.py
+++ b/src/ontoweaver/tabular.py
@@ -791,7 +791,14 @@ class YamlParser(Declare):
                         assert(type(column_names) == str)
                         column_names = [column_names]
                     gen_data = self.get_not(k_target + k_edge + k_columns, pconfig=field_dict)
-                    prop_transformer = self.make_transformer_class(transformer_type, columns=column_names, **gen_data)
+
+                    # Parse the validation rules for the output of the property transformer.
+                    p_output_validation_rules = self.get(k_validate_output, pconfig=field_dict)
+                    p_yaml_output_validation_rules = yaml.dump(p_output_validation_rules, default_flow_style=False)
+                    p_output_validator = validate.OutputValidator()
+                    p_output_validator.update_rules(pa.DataFrameSchema.from_yaml(p_yaml_output_validation_rules))
+
+                    prop_transformer = self.make_transformer_class(transformer_type, columns=column_names, output_validator=p_output_validator, **gen_data)
 
                     for object_type in object_types:
                         properties_of.setdefault(object_type, {})

--- a/src/ontoweaver/tabular.py
+++ b/src/ontoweaver/tabular.py
@@ -549,7 +549,7 @@ class Declare(base.ErrorManager):
         setattr(self.module, t.__name__, t)
         return t
 
-    def make_transformer_class(self, transformer_type, node_type=None, properties=None, edge=None, columns=None, **kwargs):
+    def make_transformer_class(self, transformer_type, node_type=None, properties=None, edge=None, columns=None, output_validator=None, **kwargs):
         """
         Create a transformer class with the given parameters.
 
@@ -559,6 +559,7 @@ class Declare(base.ErrorManager):
             properties: The properties of the transformer.
             edge: The edge type of the transformer.
             columns: The columns to be processed by the transformer.
+            output_validator: validate.OutputValidator instance for transformer output validation.
             **kwargs: Additional keyword arguments.
 
         Returns:
@@ -578,7 +579,7 @@ class Declare(base.ErrorManager):
                 else:
                     nt = "."
                 logging.debug(f"\t\tDeclare Transformer class '{transformer_type}' for node type '{nt}'")
-                return parent_t(target=node_type, properties_of=properties, edge=edge, columns=columns, **kwargs)
+                return parent_t(target=node_type, properties_of=properties, edge=edge, columns=columns, output_validator=output_validator, **kwargs)
         else:
             # logging.debug(dir(generators))
             self.error(f"Cannot find a transformer class with name `{transformer_type}`.", exception = exceptions.DeclarationError)
@@ -738,6 +739,7 @@ class YamlParser(Declare):
         k_metadata = ["metadata"]
         k_metadata_column = ["add_source_column_names_as"]
         k_validate = ["validate"]
+        k_validate_output = ["validate_output"]
 
         transformers_list = self.get(k_transformer)
 
@@ -754,6 +756,12 @@ class YamlParser(Declare):
             subject_columns = [subject_columns]
         logging.debug(f"\tDeclare subject of type: '{subject_type}', subject transformer: '{subject_transformer_class}', "
                       f"subject kwargs: '{subject_kwargs}', subject columns: '{subject_columns}'")
+
+        # Parse the validation rules for the output of the subject transformer.
+        s_output_validation_rules = self.get(k_validate_output, subject_dict[subject_transformer_class])
+        s_yaml_output_validation_rules = yaml.dump(s_output_validation_rules, default_flow_style=False)
+        s_output_validator = validate.OutputValidator()
+        s_output_validator.update_rules(pa.DataFrameSchema.from_yaml(s_yaml_output_validation_rules))
 
         # Then, parse property mappings.
         logging.debug(f"Parse properties...")
@@ -798,7 +806,7 @@ class YamlParser(Declare):
         source_t = self.make_node_class(subject_type, properties_of.get(subject_type, {}))
         subject_transformer = self.make_transformer_class(
             columns=subject_columns, transformer_type=subject_transformer_class,
-            node_type=source_t, properties=properties_of.get(subject_type, {}), **subject_kwargs)
+            node_type=source_t, properties=properties_of.get(subject_type, {}), output_validator=s_output_validator, **subject_kwargs)
         logging.debug(f"\tDeclared subject transformer: {subject_transformer}")
 
         extracted_metadata = self._extract_metadata(k_metadata_column, metadata_list, metadata, subject_type, subject_columns)
@@ -861,10 +869,16 @@ class YamlParser(Declare):
                             logging.debug(f"\tDeclare edge for `{edge}`...")
                             edge_t = self.make_edge_class(edge, source_t, target_t, properties_of.get(edge, {}))
 
+                        # Parse the validation rules for the output of the transformer.
+                        output_validation_rules = self.get(k_validate_output, pconfig=field_dict)
+                        yaml_output_validation_rules = yaml.dump(output_validation_rules, default_flow_style=False)
+                        output_validator = validate.OutputValidator()
+                        output_validator.update_rules(pa.DataFrameSchema.from_yaml(yaml_output_validation_rules))
+
                         logging.debug(f"\tDeclare transformer `{transformer_type}`...")
                         transformers.append(self.make_transformer_class(
                             transformer_type=transformer_type, node_type=target_t,
-                            properties=properties_of.get(target, {}), edge=edge_t, columns=columns, **gen_data))
+                            properties=properties_of.get(target, {}), edge=edge_t, columns=columns, output_validator=output_validator, **gen_data))
                         logging.debug(f"\t\tDeclared mapping `{columns}` => `{edge_t.__name__}`")
                     elif (target and not edge) or (edge and not target):
                         self.error(f"Cannot declare the mapping  `{columns}` => `{edge}` (target: `{target}`), missing either an object or a relation.", "transformers", n_transformer, indent=2, exception = exceptions.MissingDataError)

--- a/src/ontoweaver/validate.py
+++ b/src/ontoweaver/validate.py
@@ -1,5 +1,8 @@
 import logging
+import math
 from abc import ABCMeta
+
+import pandas as pd
 import pandera as pa
 from pandera import Column, Check
 
@@ -59,19 +62,42 @@ class InputValidator(Validator):
         """
         super().__call__(df)
 
+
+def valid(val):
+    """Check if a value is valid.
+    Args:
+        val: The value to check.
+    """
+    
+    if pd.api.types.is_numeric_dtype(type(val)):
+        if (math.isnan(val) or val == float("nan")):
+            return False
+
+    elif str(val).lower() == "nan" or val == "":
+        return False
+
+    return True
+
+
 class OutputValidator(Validator):
     """Class used for transformer output data validation against a schema.
     The schema contains some general rules for the output data frame expected by default. The user can add additional rules
     to the schema for each transformer type used on each column. The class uses the Pandera package to validate the data frame."""
 
     def __init__(self,
-                 validation_rules: pa.DataFrameSchema = pa.DataFrameSchema({ "cell_value": Column(str),})):
+                validation_rules: pa.DataFrameSchema = pa.DataFrameSchema({
+                "cell_value": Column(
+                    object,  # Use object to allow multiple types
+                    checks=Check(valid, element_wise=True, error="Invalid value found.")
+                )
+            })):
         """Constructor for the OutputValidator class.
 
         Args:
             validation_rules: The schema used for validation.
         """
         super().__init__(validation_rules)
+
 
     def __call__(self, df):
         """
@@ -87,8 +113,7 @@ class OutputValidator(Validator):
             try:
                 self.validation_rules.validate(df)
                 return True
-            except pa.errors.SchemaErrors as exc:
-                logging.warning(f"Validation failed: {exc.failure_cases}")
+            except:
                 return False
 
         else:

--- a/src/ontoweaver/validate.py
+++ b/src/ontoweaver/validate.py
@@ -1,0 +1,55 @@
+from abc import ABCMeta
+import pandera as pa
+import yaml
+from pandera import Column, Check
+
+
+class Validator(metaclass=ABCMeta):
+    """Class used for data validation against a schema. The class uses the Pandera package to validate the data frame."""
+
+    def __init__(self, validation_rules: pa.DataFrameSchema = None):
+        self.validation_rules: pa.DataFrameSchema = validation_rules
+
+    def __call__(self, df):
+        """
+        Validate the data frame against the schema.
+
+        Args:
+            df: The data frame to validate.
+
+        Returns:
+            bool: True if the data frame is valid, False otherwise.
+        """
+        if self.validation_rules:
+            try:
+                self.validation_rules.validate(df)
+                return True
+            except pa.errors.SchemaErrors as exc:
+                print(exc.failure_cases)
+        else:
+            raise ValueError("No schema provided for validation.")
+
+class InputValidator(Validator):
+    """Class used for input data validation against a schema. The class uses the Pandera package to validate the data frame."""
+
+    def __init__(self, validation_rules: pa.DataFrameSchema = None):
+        super().__init__(validation_rules)
+
+    def __call__(self, df):
+        super().__call__(df)
+
+class OutputValidator(Validator):
+    """Class used for transformer output data validation against a schema.
+    The schema contains some general rules for the output data frame expected by default. The user can add additional rules
+    to the schema for each transformer type used on each column. The class uses the Pandera package to validate the data frame."""
+
+    def __init__(self,
+                 validation_rules: pa.DataFrameSchema = pa.DataFrameSchema({ "column2": Column(float, Check(lambda s: s < -1.2))})):
+        super().__init__(validation_rules)
+
+
+
+        super().__init__(validation_rules)
+
+    def __call__(self, df):
+        super().__call__(df)

--- a/src/ontoweaver/validate.py
+++ b/src/ontoweaver/validate.py
@@ -1,6 +1,6 @@
+import logging
 from abc import ABCMeta
 import pandera as pa
-import yaml
 from pandera import Column, Check
 
 
@@ -8,6 +8,12 @@ class Validator(metaclass=ABCMeta):
     """Class used for data validation against a schema. The class uses the Pandera package to validate the data frame."""
 
     def __init__(self, validation_rules: pa.DataFrameSchema = None):
+        """Constructor for the Validator class.
+
+        Args:
+            validation_rules: The schema used for validation.
+        """
+
         self.validation_rules: pa.DataFrameSchema = validation_rules
 
     def __call__(self, df):
@@ -33,9 +39,24 @@ class InputValidator(Validator):
     """Class used for input data validation against a schema. The class uses the Pandera package to validate the data frame."""
 
     def __init__(self, validation_rules: pa.DataFrameSchema = None):
+        """Constructor for the InputValidator class.
+
+        Args:
+            validation_rules: The schema used for validation.
+        """
+
         super().__init__(validation_rules)
 
     def __call__(self, df):
+        """
+        Validate the data frame against the schema.
+
+        Args:
+            df: The data frame to validate.
+
+        Returns:
+            bool: True if the data frame is valid, False otherwise.
+        """
         super().__call__(df)
 
 class OutputValidator(Validator):
@@ -44,12 +65,47 @@ class OutputValidator(Validator):
     to the schema for each transformer type used on each column. The class uses the Pandera package to validate the data frame."""
 
     def __init__(self,
-                 validation_rules: pa.DataFrameSchema = pa.DataFrameSchema({ "column2": Column(float, Check(lambda s: s < -1.2))})):
-        super().__init__(validation_rules)
+                 validation_rules: pa.DataFrameSchema = pa.DataFrameSchema({ "cell_value": Column(str),})):
+        """Constructor for the OutputValidator class.
 
-
-
+        Args:
+            validation_rules: The schema used for validation.
+        """
         super().__init__(validation_rules)
 
     def __call__(self, df):
-        super().__call__(df)
+        """
+        Validate the data frame against the schema.
+
+        Args:
+            df: The data frame to validate.
+
+        Returns:
+            bool: True if the data frame is valid, False otherwise.
+        """
+        if self.validation_rules:
+            try:
+                self.validation_rules.validate(df)
+                return True
+            except pa.errors.SchemaErrors as exc:
+                logging.warning(f"Validation failed: {exc.failure_cases}")
+                return False
+
+        else:
+            raise ValueError("No schema provided for validation.")
+
+    def update_rules(self, new_rules):
+        """Update the validation schema with additional rules.
+
+        Args:
+            new_rules: The additional rules to be added to the schema.
+        """
+        if not isinstance(new_rules, pa.DataFrameSchema):
+            raise ValueError("new_rules must be a Pandera DataFrameSchema instance.")
+
+        # Merge the existing rules with the new ones
+        merged_rules = self.validation_rules.columns.copy() if self.validation_rules else {}
+        merged_rules.update(new_rules.columns)
+
+        # Update the validation rules
+        self.validation_rules = pa.DataFrameSchema(merged_rules)

--- a/tests/validate_input/data.csv
+++ b/tests/validate_input/data.csv
@@ -1,0 +1,4 @@
+"variant_id","patient"
+0,A
+1,E
+2,C

--- a/tests/validate_input/mapping.yaml
+++ b/tests/validate_input/mapping.yaml
@@ -1,0 +1,52 @@
+row:
+   rowIndex:
+      to_subject: variant
+      validate_output:
+          columns:
+              cell_value:
+                dtype: str
+                checks:
+                    isin:
+                        value:
+                            - '0'
+                            - '1'
+                            - '2'
+                            - '3'
+transformers:
+    - map:
+        columns:
+            - patient
+        to_object: patient
+        via_relation: patient_has_variant
+        validate_output:
+            columns:
+                cell_value:
+                    dtype: str
+                    checks:
+                        isin:
+                            value:
+                                - A
+                                - B
+                                - C
+validate:
+  columns:
+    variant_id:
+      dtype: int64
+      checks:
+        in_range:
+          min_value: 0
+          max_value: 3
+          include_min: true
+          include_max: true
+    patient:
+      dtype: str
+      checks:
+        isin:
+          value:
+            - A
+            - B
+            - C
+
+
+
+


### PR DESCRIPTION
- Specific module for validation classes.
- User-defined validation strategy in yaml mappings according to Pandera ([https://pandera.readthedocs.io/en/stable/index.html](url)) package.
- Standalone `--validate-only` command in CLI with specific exit codes.
- Test for data validation.