### PR TITLE
Fix data validation bugs.

### DIFF
--- a/src/ontoweaver/__init__.py
+++ b/src/ontoweaver/__init__.py
@@ -280,16 +280,10 @@ def validate_input_data(filename_to_mapping: dict, separator = None, **kwargs):
         with open(mapping_file) as fd:
             yaml_mapping = yaml.full_load(fd)
 
-        parser = tabular.YamlParser(yaml_mapping, types)
-        mapping = parser()
-
-        adapter = tabular.PandasAdapter(
-            table,
-            *mapping,
-        )
+        validator = tabular.YamlParser(yaml_mapping, types)._get_input_validation_rules()
 
         try:
-            adapter.validator(table)
+            validator(table)
             return True
         except pa.errors.SchemaErrors as exc:
             logger.error(f"Validation failed for {exc.failure_cases}.")
@@ -311,16 +305,10 @@ def validate_input_data_loaded(dataframe, loaded_mapping):
         bool: True if the data is valid, False otherwise.
     """
 
-    parser = tabular.YamlParser(loaded_mapping, types)
-    mapping = parser()
-
-    adapter = tabular.PandasAdapter(
-        dataframe,
-        *mapping,
-    )
+    validator = tabular.YamlParser(loaded_mapping, types)._get_input_validation_rules()
 
     try:
-        adapter.validator(dataframe)
+        validator(dataframe)
         return True
     except pa.errors.SchemaErrors as exc:
         logger.error(f"Validation failed for {exc.failure_cases}.")

--- a/src/ontoweaver/__init__.py
+++ b/src/ontoweaver/__init__.py
@@ -28,7 +28,7 @@ logger = logging.getLogger("ontoweaver")
 
 __all__ = ['Node', 'Edge', 'Transformer', 'Adapter', 'All', 'tabular', 'types', 'transformer', 'serialize', 'congregate', 'merge', 'fuse', 'fusion', 'exceptions', 'logger']
 
-def read_file(filename, separator = None,  **kwargs):
+def read_file(filename, **kwargs):
     """Read a file with Pandas, using its extension to guess its format.
 
     If no additional arguments are passed, it will call the
@@ -49,10 +49,9 @@ def read_file(filename, separator = None,  **kwargs):
 
     # We probably don't want NaN as a default,
     # since they tend to end up in a label.
-    if not kwargs:
-        kwargs = {'na_filter': True,
-                  "engine": "python"} #'c' engine does not support regex separators (separators > 1 char and different
-                                      # from '\s+' are interpreted as regex) which results in an error.
+    kwargs.update({'na_filter': True,
+                'engine': 'python'}) #'c' engine does not support regex separators (separators > 1 char and different
+                                  # from '\s+' are interpreted as regex) which results in an error.
 
     read_funcs = {
         '.csv'    : pd.read_csv,
@@ -87,7 +86,7 @@ def read_file(filename, separator = None,  **kwargs):
         logger.error(msg)
         raise exceptions.FeatureError(msg)
 
-    return read_funcs[ext](filename, sep=separator, **kwargs) if separator else read_funcs[ext](filename, **kwargs)
+    return read_funcs[ext](filename, **kwargs)
 
 
 def extract_reconciliate_write(biocypher_config_path, schema_path, filename_to_mapping = None, dataframe = None, loaded_mapping = None, parallel_mapping = 0, separator = None, affix = "none", affix_separator = ":", raise_errors = True, **kwargs):
@@ -259,13 +258,12 @@ def reconciliate_write(nodes: list[Tuple], edges: list[Tuple], biocypher_config_
     return import_file
 
 
-def validate_input_data(filename_to_mapping: dict, separator = None, **kwargs):
+def validate_input_data(filename_to_mapping: dict, **kwargs):
     """
     Validates the data files based on provided rules in configuration.
 
     Args:
         filename_to_mapping (dict): a dictionary mapping data file path to the OntoWeaver mapping yaml file.
-        separator (str, optional): The separator used in the data file. Defaults to None.
         kwargs: A dictionary of arguments to pass to pandas.read_* functions.
 
     Returns:
@@ -275,7 +273,7 @@ def validate_input_data(filename_to_mapping: dict, separator = None, **kwargs):
     assert(type(filename_to_mapping) == dict) # data_file => mapping_file
 
     for data_file, mapping_file in filename_to_mapping.items():
-        table = read_file(data_file, separator, **kwargs)
+        table = read_file(data_file, **kwargs)
 
         with open(mapping_file) as fd:
             yaml_mapping = yaml.full_load(fd)

--- a/src/ontoweaver/__init__.py
+++ b/src/ontoweaver/__init__.py
@@ -90,7 +90,7 @@ def read_file(filename, separator = None,  **kwargs):
     return read_funcs[ext](filename, sep=separator, **kwargs) if separator else read_funcs[ext](filename, **kwargs)
 
 
-def extract_reconciliate_write(biocypher_config_path, schema_path, filename_to_mapping = None, dataframe_to_mapping = None, parallel_mapping = 0, separator = None, affix = "none", affix_separator = ":", raise_errors = True, **kwargs):
+def extract_reconciliate_write(biocypher_config_path, schema_path, filename_to_mapping = None, dataframe = None, loaded_mapping = None, parallel_mapping = 0, separator = None, affix = "none", affix_separator = ":", raise_errors = True, **kwargs):
     """Calls several mappings, each on the related Pandas-readable tabular data file,
        then reconciliate duplicated nodes and edges (on nodes' IDs, merging properties in lists),
        then export everything with BioCypher.
@@ -100,7 +100,8 @@ def extract_reconciliate_write(biocypher_config_path, schema_path, filename_to_m
            biocypher_config_path: the BioCypher configuration file.
            schema_path: the assembling schema file.
            filename_to_mapping: a dictionary mapping data file path to the OntoWeaver mapping yaml file to extract them.
-           dataframe_to_mapping: a dictionary mapping loaded Pandas data frame to the loaded yaml mapping object.
+           dataframe: The loaded pandas DataFrame to map.
+           loaded_mapping: The mapping object to use for validation.
            parallel_mapping (int): Number of workers to use in parallel mapping. Defaults to 0 for sequential processing.
            separator (str, optional): The separator to use for combining values in reconciliation. Defaults to None.
            affix (str, optional): The affix to use for type inclusion. Defaults to "none".
@@ -136,23 +137,19 @@ def extract_reconciliate_write(biocypher_config_path, schema_path, filename_to_m
             nodes += adapter.nodes
             edges += adapter.edges
 
-    if dataframe_to_mapping:
+    if loaded_mapping and dataframe:
 
-        assert(type(dataframe_to_mapping) == dict) # data_frame => yaml_object
+        adapter = tabular.extract_table(
+            dataframe,
+            loaded_mapping,
+            parallel_mapping=parallel_mapping,
+            affix=affix,
+            separator=affix_separator,
+            raise_errors = raise_errors,
+        )
 
-        for data_frame, yaml_object in dataframe_to_mapping.items():
-
-            adapter = tabular.extract_table(
-                data_frame,
-                yaml_object,
-                parallel_mapping=parallel_mapping,
-                affix=affix,
-                separator=affix_separator,
-                raise_errors = raise_errors,
-            )
-
-            nodes += adapter.nodes
-            edges += adapter.edges
+        nodes += adapter.nodes
+        edges += adapter.edges
 
     fnodes, fedges = fusion.reconciliate(nodes, edges, separator = separator)
 
@@ -170,13 +167,14 @@ def extract_reconciliate_write(biocypher_config_path, schema_path, filename_to_m
     return import_file
 
 
-def extract(filename_to_mapping = None, dataframe_to_mapping = None, parallel_mapping = 0, affix="none", affix_separator=":", raise_errors = True, **kwargs) -> Tuple[list[Tuple], list[Tuple]]:
+def extract(filename_to_mapping = None, dataframe = None, loaded_mapping = None, parallel_mapping = 0, affix="none", affix_separator=":", raise_errors = True, **kwargs) -> Tuple[list[Tuple], list[Tuple]]:
     """
     Extracts nodes and edges from tabular data files based on provided mappings.
 
     Args:
         filename_to_mapping (dict): a dictionary mapping data file path to the OntoWeaver mapping yaml file to extract them.
-        dataframe_to_mapping: a dictionary mapping loaded Pandas data frame to the loaded yaml mapping object.
+        dataframe: The loaded pandas DataFrame to map.
+        loaded_mapping: The mapping object to use for validation.
         parallel_mapping (int): Number of workers to use in parallel mapping. Defaults to 0 for sequential processing.
         affix (str, optional): The affix to use for type inclusion. Defaults to "none".
         affix_separator: The character(s) separating the label from its type affix. Defaults to ":".
@@ -213,23 +211,19 @@ def extract(filename_to_mapping = None, dataframe_to_mapping = None, parallel_ma
             edges += adapter.edges
 
 
-    if dataframe_to_mapping:
+    if dataframe and loaded_mapping:
 
-        assert(type(dataframe_to_mapping) == dict) # data_frame => yaml_object
+        adapter = tabular.extract_table(
+            dataframe,
+            loaded_mapping,
+            parallel_mapping=parallel_mapping,
+            affix=affix,
+            separator=affix_separator,
+            raise_errors = raise_errors,
+        )
 
-        for data_frame, yaml_object in dataframe_to_mapping.items():
-
-            adapter = tabular.extract_table(
-                data_frame,
-                yaml_object,
-                parallel_mapping=parallel_mapping,
-                affix=affix,
-                separator=affix_separator,
-                raise_errors = raise_errors,
-            )
-
-            nodes += adapter.nodes
-            edges += adapter.edges
+        nodes += adapter.nodes
+        edges += adapter.edges
 
     return nodes, edges
 
@@ -244,7 +238,6 @@ def reconciliate_write(nodes: list[Tuple], edges: list[Tuple], biocypher_config_
         biocypher_config_path (str): the BioCypher configuration file.
         schema_path (str): the assembling schema file
         separator (str, optional): The separator to use for combining values in reconciliation. Defaults to None.
-        raise_errors: Whether to raise errors encountered during the mapping, and stop the mapping process. Defaults to True.
 
     Returns:
         str: The path to the import file.
@@ -306,19 +299,19 @@ def validate_input_data(filename_to_mapping: dict, separator = None, **kwargs):
             return False
 
 
-def validate_input_data_loaded(dataframe, mapping):
+def validate_input_data_loaded(dataframe, loaded_mapping):
     """
     Validates the data files based on provided rules in configuration.
 
     Args:
          dataframe: The loaded pandas DataFrame to validate.
-         mapping: The mapping object to use for validation.
+         loaded_mapping: The mapping object to use for validation.
 
     Returns:
         bool: True if the data is valid, False otherwise.
     """
 
-    parser = tabular.YamlParser(mapping, types)
+    parser = tabular.YamlParser(loaded_mapping, types)
     mapping = parser()
 
     adapter = tabular.PandasAdapter(

--- a/src/ontoweaver/tabular.py
+++ b/src/ontoweaver/tabular.py
@@ -737,6 +737,23 @@ class YamlParser(Declare):
         else:
             return None
 
+    def _get_input_validation_rules(self,):
+        """
+        Extract input data validation schema from yaml file and instantiate a Pandera DataFrameSchema object and validator.
+        """
+        k_validate = ["validate"]
+        validation_rules = self.get(k_validate)
+        yaml_validation_rules = yaml.dump(validation_rules, default_flow_style=False)
+        validator = None
+
+        try:
+            validation_schema = pa.DataFrameSchema.from_yaml(yaml_validation_rules)
+            validator = validate.InputValidator(validation_schema, raise_errors=self.raise_errors)
+        except Exception as e:
+            self.error(f"Failed to parse the input validation schema: {e}", exception=exceptions.ConfigError)
+
+        return validator
+
     def __call__(self):
         """
         Parse the configuration and return the subject transformer and transformers.
@@ -762,7 +779,6 @@ class YamlParser(Declare):
         k_transformer = ["transformers"]
         k_metadata = ["metadata"]
         k_metadata_column = ["add_source_column_names_as"]
-        k_validate = ["validate"]
         k_validate_output = ["validate_output"]
 
         transformers_list = self.get(k_transformer)
@@ -924,16 +940,7 @@ class YamlParser(Declare):
                         if extracted_metadata:
                             metadata.update(extracted_metadata)
 
-        # Extract input data validation schema from yaml file and instantiate a Pandera DataFrameSchema object and validator.
-        validation_rules = self.get(k_validate)
-        yaml_validation_rules = yaml.dump(validation_rules, default_flow_style=False)
-        validator = None
-
-        try:
-            validation_schema = pa.DataFrameSchema.from_yaml(yaml_validation_rules)
-            validator = validate.InputValidator(validation_schema, raise_errors = self.raise_errors)
-        except Exception as e:
-            self.error(f"Failed to parse the input validation schema: {e}", exception = exceptions.ConfigError)
+        validator = self._get_input_validation_rules()
 
         logger.debug(f"source class: {source_t}")
         logger.debug(f"properties_of: {properties_of}")

--- a/src/tools/ontoweave.py
+++ b/src/tools/ontoweave.py
@@ -137,6 +137,9 @@ if __name__ == "__main__":
     do.add_argument("-v", "--validate-only", action="store_true",
                     help="Only validate the given input data, do not apply the mapping.")
 
+    do.add_argument("-Ds", "--database-sep", metavar="CHARACTER",
+        help="Character used to separate values in the database.")
+
     do.add_argument("-D", "--debug", action="store_true",
         help=f"Run in debug mode. implies `--log-level DEBUG`, disables `--pass-errors`. NOTE: this will disable explicit return codes and show the call stack.")
 
@@ -147,7 +150,7 @@ if __name__ == "__main__":
             logger.setLevel("DEBUG")
             logger.warning(f"You asked for --debug but set --log-level={asked.log_level}, I will ignore that and set --log-level=DEBUG")
         if asked.pass_errors:
-            loger.warning(f"You asked for --debug but passed --pass-errors, I will ignore that.")
+            logger.warning(f"You asked for --debug but passed --pass-errors, I will ignore that.")
         asked.log_level = "DEBUG"
         asked.pass_errors = False
 
@@ -209,7 +212,7 @@ if __name__ == "__main__":
     # Validate the input data if asked.
     if asked.validate_only:
         logger.info(f"Validating input data frame...")
-        if ontoweaver.validate_input_data(filename_to_mapping=mappings, raise_errors = not asked.pass_errors):
+        if ontoweaver.validate_input_data(filename_to_mapping=mappings, separator=asked.database_sep):
             logger.info(f"  Input data is valid according to provided rules.")
             sys.exit(0)
         else:

--- a/src/tools/ontoweave.py
+++ b/src/tools/ontoweave.py
@@ -212,7 +212,7 @@ if __name__ == "__main__":
     # Validate the input data if asked.
     if asked.validate_only:
         logger.info(f"Validating input data frame...")
-        if ontoweaver.validate_input_data(filename_to_mapping=mappings, separator=asked.database_sep):
+        if ontoweaver.validate_input_data(filename_to_mapping=mappings, sep=asked.database_sep):
             logger.info(f"  Input data is valid according to provided rules.")
             sys.exit(0)
         else:


### PR DESCRIPTION
- Enable passing separator to `read_file` #111 
- Change `na_filter` to `True` since a filtering mechanism for nullable values can be set up in Pandera configuration, and setting `na_filter` to `False` causes errors with expected value validation with Pandera.
- Do not try hashing in memory data frames #110 
- Enable data validation with no adapter instantiation and no type mapping in the yaml config declared. #109 