### PR TITLE
Doc fusion diagrams

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,11 +32,22 @@ autodoc_default_options = {
 autoclass_content = 'both'
 
 templates_path = ['_templates']
-exclude_patterns = []
 
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", "biocypher-log/"]
 
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ["_static"]
+
+html_css_files = [
+    "css/custom.css",
+]
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
-html_theme = 'furo'
+html_theme = 'sphinx_rtd_theme'

--- a/docs/readme_sections/data_validation.rst
+++ b/docs/readme_sections/data_validation.rst
@@ -17,13 +17,15 @@ not result in an empty value and will be a string.
 Here’s an example of what a YAML configuration file for a simple
 database would look like:
 
-::
-
-   | variant_id | patient |
-   |------------|---------|
-   |      0     |    A    |
-   |      1     |    B    |
-   |      2     |    C    |
++------------+---------+
+| variant_id | patient |
++============+=========+
+|      0     |    A    |
++------------+---------+
+|      1     |    B    |
++------------+---------+
+|      2     |    C    |
++------------+---------+
 
 Let’s first define a simple mapping configuration for the above data. In
 the example below we are mapping the column ``patient`` to a ``patient``

--- a/docs/readme_sections/how_to.rst
+++ b/docs/readme_sections/how_to.rst
@@ -46,16 +46,21 @@ Edges can be extracted from the mapping configuration, by defining a
 the ``from_subject`` is the node type from which the edge will start,
 and the ``to_object`` is the node type to which the edge will end.
 
-For example, consider the following mapping configuration for the sample
-dataset below:
+For example, for the sample dataset below:
 
-::
++----+----------+---------+
+| id | patient  | sample  |
++====+==========+=========+
+| 0  | patient1 | sample1 |
++----+----------+---------+
+| 1  | patient2 | sample2 |
++----+----------+---------+
+| 2  | patient3 | sample3 |
++----+----------+---------+
+| 3  | patient4 | sample4 |
++----+----------+---------+
 
-   id  patient         sample
-   0   patient1    sample1
-   1   patient2    sample2
-   2   patient3    sample3
-   3   patient4    sample4
+Consider the following mapping configuration:
 
 .. code:: yaml
 

--- a/docs/readme_sections/information_fusion.rst
+++ b/docs/readme_sections/information_fusion.rst
@@ -123,44 +123,44 @@ specific property.
 For example, with 4 nodes all having the same label, using the `IDLabel`
 serializer, the `Node` congregater will detect three duplicated nodes::
     nodes ==
-    ⎡ ┌node1───────┐ ┌node2───────┐ ┌node3───────┐ ┌node4───────┐ ⎤
-    ⎢ │   ID: BRCA2│ │   ID: BRCA2│ │   ID: BRCA2│ │   ID: BRCA2│ ⎥
-    ⎢ │Label: gene │ │Label: gene │ │Label: prot │ │Label: gene │ ⎥
-    ⎢ │Props:      │,│Props:      │,│Props:      │,│Props:      │ ⎥
-    ⎢ │⎧  source: A│ │⎧  source: B│ │⎧  source: B│ │⎧  source: B│ ⎥
-    ⎢ │⎨ version: 1│ │⎨ version: 2│ │⎨ version: 2│ │⎨ version: 3│ ⎥
-    ⎢ │⎩   level: I│ │⎩   level: I│ │⎩   level:II│ │⎩   level: I│ ⎥
-    ⎣ └────────────┘ └────────────┘ └────────────┘ └────────────┘ ⎦
-            │               │              │
-          >>> on_IDLabel = ontoweaver.serialize.IDLabel()
-          >>> for n in nodes:
-          >>>     on_IDLabel(n)
-            │               │              │
-            ▼               ▼              ▼
-    keys=["BRCA2gene" , "BRCA2gene" , "BRCA2prot"]
-    └───────────────────────┬──────────────────────┘
-                            │
-          >>> congregate = ontoweaver.congregate.Nodes(on_IDlabel)
-          >>> congregate(nodes)
-                            │
-                            ▼
+    ⎡ ┌node1───────┐  ┌node2───────┐  ┌node3───────┐  ┌node4───────┐  ⎤
+    ⎢ │   ID: BRCA2┼┐ │   ID: BRCA2┼┐ │   ID: BRCA2┼┐ │   ID: BRCA2┼┐ ⎥
+    ⎢ │Label: gene ┼┤ │Label: gene ┼┤ │Label: prot ┼┤ │Label: gene ┼┤ ⎥
+    ⎢ │Props:      ││,│Props:      ││,│Props:      ││,│Props:      ││ ⎥
+    ⎢ │⎧ source: A⎫││ │⎧ source: B⎫││ │⎧ source: B⎫││ │⎧ source: B⎫││ ⎥
+    ⎢ │⎨version: 1⎬││ │⎨version: 2⎬││ │⎨version: 2⎬││ │⎨version: 3⎬││ ⎥
+    ⎢ │⎩  level: I⎭││ │⎩  level: I⎭││ │⎩  level:II⎭││ │⎩  level: I⎭││ ⎥
+    ⎣ └────────────┘│ └────────────┘│ └────────────┘│ └────────────┘│ ⎦
+                    │               │               │               │
+            >>> on_IDLabel = ontoweaver.serialize.IDLabel()         │
+            >>> for n in nodes:     │               │               │
+            >>>     on_IDLabel(n)   │               │               │
+                    │               │               │               │
+                    ▼               ▼               ▼               ▼
+       keys = ["BRCA2gene"  ,  "BRCA2gene"  ,  "BRCA2prot"  ,  "BRCA2gene"]
+      └───┬────────────────────────────────────────────────────────────────┘
+          │                          
+          │ >>> congregate = ontoweaver.congregate.Nodes(on_IDlabel)
+          │ >>> congregate(nodes)     
+          │                          
+          ▼                          
     congregate.duplicates() ==
     ⎧             ⎡ ┌node1───────┐ ┌node2───────┐ ┌node4───────┐ ⎤ ⎫
     ⎪             ⎢ │   ID: BRCA2│ │   ID: BRCA2│ │   ID: BRCA2│ ⎥ ⎪
     ⎪             ⎢ │Label: gene │ │Label: gene │ │Label: gene │ ⎥ ⎪
     ⎪"BRCA2gene": ⎢ │Props:      │,│Props:      │,│Props:      │ ⎥ ⎪
-    ⎪             ⎢ │⎧  source: A│ │⎧  source: B│ │⎧  source: B│ ⎥ ⎪
-    ⎪             ⎢ │⎨ version: 1│ │⎨ version: 2│ │⎨ version: 3│ ⎥ ⎪
-    ⎪             ⎢ │⎩   level: I│ │⎩   level: I│ │⎩   level: I│ ⎥ ⎪
+    ⎪             ⎢ │⎧ source: A⎫│ │⎧ source: B⎫│ │⎧ source: B⎫│ ⎥ ⎪
+    ⎪             ⎢ │⎨version: 1⎬│ │⎨version: 2⎬│ │⎨version: 3⎬│ ⎥ ⎪
+    ⎪             ⎢ │⎩  level: I⎭│ │⎩  level: I⎭│ │⎩  level: I⎭│ ⎥ ⎪
     ⎪             ⎣ └────────────┘ └────────────┘ └────────────┘ ⎦ ⎪
     ⎨ ,                                                            ⎬
     ⎪             ⎡ ┌node3───────┐ ⎤                               ⎪
     ⎪             ⎢ │   ID: BRCA2│ ⎥                               ⎪
     ⎪             ⎢ │Label: prot │ ⎥                               ⎪
     ⎪"BRCA2prot": ⎢ │Props:      │ ⎥                               ⎪
-    ⎪             ⎢ │⎧  source: B│ ⎥                               ⎪
-    ⎪             ⎢ │⎨ version: 2│ ⎥                               ⎪
-    ⎪             ⎢ │⎩   level:II│ ⎥                               ⎪
+    ⎪             ⎢ │⎧ source: B⎫│ ⎥                               ⎪
+    ⎪             ⎢ │⎨version: 2⎬│ ⎥                               ⎪
+    ⎪             ⎢ │⎩  level:II⎭│ ⎥                               ⎪
     ⎩             ⎣ └────────────┘ ⎦                               ⎭
 
 For step 1, OntoWeaver provides the ``serialize`` module, which allows
@@ -243,9 +243,9 @@ merged into a single node in two steps::
     ⎪             ⎢ │   ID: BRCA2│ │   ID: BRCA2│ │   ID: BRCA2│ ⎥ ⎪
     ⎪             ⎢ │Label: gene │ │Label: gene │ │Label: gene │ ⎥ ⎪
     ⎨"BRCA2gene": ⎢ │Props:      │,│Props:      │,│Props:      │ ⎥ ⎬
-    ⎪             ⎢ │⎧  source: A│ │⎧  source: B│ │⎧  source: B│ ⎥ ⎪
-    ⎪             ⎢ │⎨ version: 1│ │⎨ version: 2│ │⎨ version: 3│ ⎥ ⎪
-    ⎪             ⎢ │⎩   level: I│ │⎩   level: I│ │⎩   level: I│ ⎥ ⎪
+    ⎪             ⎢ │⎧ source: A⎫│ │⎧ source: B⎫│ │⎧ source: B⎫│ ⎥ ⎪
+    ⎪             ⎢ │⎨version: 1⎬│ │⎨version: 2⎬│ │⎨version: 3⎬│ ⎥ ⎪
+    ⎪             ⎢ │⎩  level: I⎭│ │⎩  level: I⎭│ │⎩  level: I⎭│ ⎥ ⎪
     ⎩             ⎣ └────────────┘ └────────────┘ └────────────┘ ⎦ ⎭
                            ▲              ▲              │
                            │              └──────────────┘
@@ -259,15 +259,15 @@ merged into a single node in two steps::
 
 Each `Reduce` step would consists in calling `Members` mergers on each variable
 members, for example, for the second step::
-    fuse.Members.merge
-    ⎛            ┌node1───────┐ ┌node2─────────┐ ⎞                     ┌node────────────┐
-    ⎜            │   ID: BRCA2│ │   ID: BRCA2  │ ⎟ ──────UseFirst─────▶│   ID: BRCA2    │
-    ⎜┌key──────┐ │Label: gene │ │Label: gene   │ ⎟ ──EnsureIdenticals─▶│Label: gene     │
-    ⎜│BRCA2gene│,│Props:      │,│Props:        │ ⎟ ───────Append──────▶│Props:          │
-    ⎜└─────────┘ │⎧  source: A│ │⎧  source: B  │ ⎟  ┄┄┄┄┄set{A,B}┄┄┄┄▷ │⎧  source: A,B  │
-    ⎜            │⎨ version: 1│ │⎨ version: 2,3│ ⎟  ┄┄┄┄┄set{1,2,3}┄┄▷ │⎨ version: 1,2,3│
-    ⎜            │⎩   level: I│ │⎩   level: I  │ ⎟  ┄┄┄┄┄set{I,I}┄┄┄┄▷ │⎩   level: I    │
-    ⎝            └────────────┘ └──────────────┘ ⎠                     └────────────────┘
+    fuse.Members.merge \
+      ⎛            ┌node1───────┐ ┌node2─────────┐ ⎞                     ┌node────────────┐
+      ⎜            │   ID: BRCA2│ │   ID: BRCA2  │ ⎟ ──────UseFirst─────▶│   ID: BRCA2    │
+      ⎜┌key──────┐ │Label: gene │ │Label: gene   │ ⎟ ──EnsureIdenticals─▶│Label: gene     │
+      ⎜│BRCA2gene│,│Props:      │,│Props:        │ ⎟ ───────Append──────▶│Props:          │
+      ⎜└─────────┘ │⎧ source: A⎫│ │⎧ source: B  ⎫│ ⎟   ┄┄┄┄{A}+{B}┄┄┄┄▷  │⎧ source: A,B  ⎫│
+      ⎜            │⎨version: 1⎬│ │⎨version: 2,3⎬│ ⎟   ┄┄┄┄{1}+{2,3}┄┄▷  │⎨version: 1,2,3⎬│
+      ⎜            │⎩  level: I⎭│ │⎩  level: I  ⎭│ ⎟   ┄┄┄┄{I}+{I}┄┄┄┄▷  │⎩  level: I    ⎭│
+      ⎝            └────────────┘ └──────────────┘ ⎠                     └────────────────┘
 
 
 Once this fusion step is done, is it possible that the edges that were

--- a/docs/readme_sections/information_fusion.rst
+++ b/docs/readme_sections/information_fusion.rst
@@ -71,6 +71,32 @@ Then, the result of the reconciliation step above would be:
    # Note how "x" and "z" are separated by separator=";".
    ("id_1", "type_A", {"prop_1": "x;z", "prop_2": "y"})
 
+
+Generic fusion
+~~~~~~~~~~~~~~
+
+OntoWeaver brings a set of features that also help solving fusion problems
+that goes beyond properties reconciliation.
+
+To do so, it is allows to manage two problems:
+1. How to detect that two elements are duplicates?
+2. How to fuse duplicated element in a single one?
+
+The first problem is handled by the `Congregater` interface, which needs to
+construct a dictionary arrociating a *key* with a list of duplicated element.
+The *key* is a representation of the elements in the form of a string. If two
+elements have the same *key* then they are considered duplicates and put in the
+same list, and will be fused together in the second step.
+
+For the second problem, OntoWeaver provides three layers, depending on what one
+wants to fuse. For fusing:
+1. a whole *list of duplicated elements*, use objects implementing the low-level
+   interface `fusion.Fusioner`,
+2. two duplicated elements, use objects implementing the low-level interface
+   `fuse.Fuser`,
+3. two member variables (e.g. ID, label, properties, source or target) of two
+   duplicated elements, use the mid-level interface `merge.Merger`.
+
 Mid-level Interfaces
 ^^^^^^^^^^^^^^^^^^^^
 
@@ -81,6 +107,61 @@ The simplest approach to fusion is to define how to:
 3. fuse two type labels, and
 4. fuse two properties dictionaries, and then
 5. let OntoWeaver browse the nodes by pairs, until everything is fused.
+
+Detecting duplicates
+""""""""""""""""""""
+
+For step 1, OntoWeaver provides the `serialize` module, which allows to extract
+the part of a node (or an edge) that should be used when checking equality.
+
+To produce such a *key* from an element, OntoWeaver provides `Serializer`s. A
+serializer object takes the element as an input, and returns the string key
+representing it. For instance, it can return the concatenation of a node's ID
+and label, or the concatenation of an edge's source, target and the value of a
+specific property.
+
+For example, with 4 nodes all having the same label, using the `IDLabel`
+serializer, the `Node` congregater will detect three duplicated nodes::
+    nodes ==
+    ⎡ ┌node1───────┐ ┌node2───────┐ ┌node3───────┐ ┌node4───────┐ ⎤
+    ⎢ │   ID: BRCA2│ │   ID: BRCA2│ │   ID: BRCA2│ │   ID: BRCA2│ ⎥
+    ⎢ │Label: gene │ │Label: gene │ │Label: prot │ │Label: gene │ ⎥
+    ⎢ │Props:      │,│Props:      │,│Props:      │,│Props:      │ ⎥
+    ⎢ │⎧  source: A│ │⎧  source: B│ │⎧  source: B│ │⎧  source: B│ ⎥
+    ⎢ │⎨ version: 1│ │⎨ version: 2│ │⎨ version: 2│ │⎨ version: 3│ ⎥
+    ⎢ │⎩   level: I│ │⎩   level: I│ │⎩   level:II│ │⎩   level: I│ ⎥
+    ⎣ └────────────┘ └────────────┘ └────────────┘ └────────────┘ ⎦
+            │               │              │
+          >>> on_IDLabel = ontoweaver.serialize.IDLabel()
+          >>> for n in nodes:
+          >>>     on_IDLabel(n)
+            │               │              │
+            ▼               ▼              ▼
+    keys=["BRCA2gene" , "BRCA2gene" , "BRCA2prot"]
+    └───────────────────────┬──────────────────────┘
+                            │
+          >>> congregate = ontoweaver.congregate.Nodes(on_IDlabel)
+          >>> congregate(nodes)
+                            │
+                            ▼
+    congregate.duplicates() ==
+    ⎧             ⎡ ┌node1───────┐ ┌node2───────┐ ┌node4───────┐ ⎤ ⎫
+    ⎪             ⎢ │   ID: BRCA2│ │   ID: BRCA2│ │   ID: BRCA2│ ⎥ ⎪
+    ⎪             ⎢ │Label: gene │ │Label: gene │ │Label: gene │ ⎥ ⎪
+    ⎪"BRCA2gene": ⎢ │Props:      │,│Props:      │,│Props:      │ ⎥ ⎪
+    ⎪             ⎢ │⎧  source: A│ │⎧  source: B│ │⎧  source: B│ ⎥ ⎪
+    ⎪             ⎢ │⎨ version: 1│ │⎨ version: 2│ │⎨ version: 3│ ⎥ ⎪
+    ⎪             ⎢ │⎩   level: I│ │⎩   level: I│ │⎩   level: I│ ⎥ ⎪
+    ⎪             ⎣ └────────────┘ └────────────┘ └────────────┘ ⎦ ⎪
+    ⎨ ,                                                            ⎬
+    ⎪             ⎡ ┌node3───────┐ ⎤                               ⎪
+    ⎪             ⎢ │   ID: BRCA2│ ⎥                               ⎪
+    ⎪             ⎢ │Label: prot │ ⎥                               ⎪
+    ⎪"BRCA2prot": ⎢ │Props:      │ ⎥                               ⎪
+    ⎪             ⎢ │⎧  source: B│ ⎥                               ⎪
+    ⎪             ⎢ │⎨ version: 2│ ⎥                               ⎪
+    ⎪             ⎢ │⎩   level:II│ ⎥                               ⎪
+    ⎩             ⎣ └────────────┘ ⎦                               ⎭
 
 For step 1, OntoWeaver provides the ``serialize`` module, which allows
 to extract the part of a node or an edge) that should be used when
@@ -104,6 +185,9 @@ For example:
    congregater = congregate.Nodes(on_ID) # Instantiation.
    congregater(my_nodes) # Actual processing call.
    # congregarter now holds a dictionary of duplicated nodes.
+
+Fuse duplicates
+"""""""""""""""
 
 For steps 2 to 4, OntoWeaver provides the ``merge`` module, which
 provides ways to merge two nodes’ components into a single one. It is
@@ -136,14 +220,14 @@ For example, to fuse “congregated” nodes, one can do:
 .. code:: python
 
        # How to merge two components:
-       use_key    = merge.string.UseKey() # Instantiation.
+       use_first  = merge.string.UseFirst() # Instantiation.
        identicals = merge.string.EnsureIdentical()
        in_lists   = merge.dictry.Append(separator)
 
        # Assemble those function objects in an object that knows
        # how to apply them members by members:
        fuser = fuse.Members(base.Node,
-               merge_ID    = use_key,    # How to merge two identifiers.
+               merge_ID    = use_first,  # How to merge two identifiers.
                merge_label = identicals, # How to merge two type labels.
                merge_prop  = in_lists,   # How to merge two properties dictionaries.
            )
@@ -151,6 +235,40 @@ For example, to fuse “congregated” nodes, one can do:
        # Apply a "reduce" step (browsing pairs of nodes, until exhaustion):
        fusioner = Reduce(fuser) # Instantiation.
        fusioned_nodes = fusioner(congregater) # Call on the previously found duplicates.
+
+For example, the three duplicated nodes shown in the previous section would be
+merged into a single node in two steps::
+    congregate.duplicates() ==
+    ⎧             ⎡ ┌node1───────┐ ┌node2───────┐ ┌node4───────┐ ⎤ ⎫
+    ⎪             ⎢ │   ID: BRCA2│ │   ID: BRCA2│ │   ID: BRCA2│ ⎥ ⎪
+    ⎪             ⎢ │Label: gene │ │Label: gene │ │Label: gene │ ⎥ ⎪
+    ⎨"BRCA2gene": ⎢ │Props:      │,│Props:      │,│Props:      │ ⎥ ⎬
+    ⎪             ⎢ │⎧  source: A│ │⎧  source: B│ │⎧  source: B│ ⎥ ⎪
+    ⎪             ⎢ │⎨ version: 1│ │⎨ version: 2│ │⎨ version: 3│ ⎥ ⎪
+    ⎪             ⎢ │⎩   level: I│ │⎩   level: I│ │⎩   level: I│ ⎥ ⎪
+    ⎩             ⎣ └────────────┘ └────────────┘ └────────────┘ ⎦ ⎭
+                           ▲              ▲              │
+                           │              └──────────────┘
+                           │              FIRST Reduce step:
+                           │              merge node2 and node3 into node2.
+                           │              │
+                           └──────────────┘
+                         SECOND Reduce step:
+                         merge node1 and node2,
+                         one now have a single node.
+
+Each `Reduce` step would consists in calling `Members` mergers on each variable
+members, for example, for the second step::
+    fuse.Members.merge
+    ⎛            ┌node1───────┐ ┌node2─────────┐ ⎞                     ┌node────────────┐
+    ⎜            │   ID: BRCA2│ │   ID: BRCA2  │ ⎟ ──────UseFirst─────▶│   ID: BRCA2    │
+    ⎜┌key──────┐ │Label: gene │ │Label: gene   │ ⎟ ──EnsureIdenticals─▶│Label: gene     │
+    ⎜│BRCA2gene│,│Props:      │,│Props:        │ ⎟ ───────Append──────▶│Props:          │
+    ⎜└─────────┘ │⎧  source: A│ │⎧  source: B  │ ⎟  ┄┄┄┄┄set{A,B}┄┄┄┄▷ │⎧  source: A,B  │
+    ⎜            │⎨ version: 1│ │⎨ version: 2,3│ ⎟  ┄┄┄┄┄set{1,2,3}┄┄▷ │⎨ version: 1,2,3│
+    ⎜            │⎩   level: I│ │⎩   level: I  │ ⎟  ┄┄┄┄┄set{I,I}┄┄┄┄▷ │⎩   level: I    │
+    ⎝            └────────────┘ └──────────────┘ ⎠                     └────────────────┘
+
 
 Once this fusion step is done, is it possible that the edges that were
 defined by the initial adapters refer to node IDs that do not exist

--- a/docs/readme_sections/information_fusion.rst
+++ b/docs/readme_sections/information_fusion.rst
@@ -79,17 +79,19 @@ OntoWeaver brings a set of features that also help solving fusion problems
 that goes beyond properties reconciliation.
 
 To do so, it is allows to manage two problems:
+
 1. How to detect that two elements are duplicates?
 2. How to fuse duplicated element in a single one?
 
 The first problem is handled by the `Congregater` interface, which needs to
-construct a dictionary arrociating a *key* with a list of duplicated element.
+construct a dictionary associating a *key* with a list of duplicated elements.
 The *key* is a representation of the elements in the form of a string. If two
 elements have the same *key* then they are considered duplicates and put in the
 same list, and will be fused together in the second step.
 
 For the second problem, OntoWeaver provides three layers, depending on what one
 wants to fuse. For fusing:
+
 1. a whole *list of duplicated elements*, use objects implementing the low-level
    interface `fusion.Fusioner`,
 2. two duplicated elements, use objects implementing the low-level interface
@@ -225,7 +227,7 @@ For example, to fuse “congregated” nodes, one can do:
        in_lists   = merge.dictry.Append(separator)
 
        # Assemble those function objects in an object that knows
-       # how to apply them members by members:
+       # how to apply them member by member:
        fuser = fuse.Members(base.Node,
                merge_ID    = use_first,  # How to merge two identifiers.
                merge_label = identicals, # How to merge two type labels.

--- a/docs/readme_sections/mapping_api.rst
+++ b/docs/readme_sections/mapping_api.rst
@@ -372,17 +372,21 @@ Multi-type Transformers
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 In some cases there might be a need to apply multiple type mappings to
-cell values within a single column. For example, in the table below, you
-might want to map the column ``WORDS`` based on the word type detected.
+cell values within a single column. For example, having the table below:
 
-::
++------+--------------+
+| LINE | WORDS        |
++======+==============+
+|   0  | sensitive    |
++------+--------------+
+|   1  | sensitivity  |
++------+--------------+
+|   2  | productive   |
++------+--------------+
+|   3  | productivity |
++------+--------------+
 
-   | LINE | WORDS |
-   | ---- | ---------- |
-   | 0 | sensitive |
-   | 1 | sensitivity |
-   | 2 | productive |
-   | 3 | productivity |
+You might want to map the column ``WORDS`` based on the word type detected:
 
 .. code:: yaml
 

--- a/docs/readme_sections/overview.rst
+++ b/docs/readme_sections/overview.rst
@@ -8,8 +8,6 @@ OntoWeaver allows writing a simple declarative mapping to express how
 columns from a `Pandas <https://pandas.pydata.org/>`__ table are to be
 converted as typed nodes or edges in an SKG.
 
-|OntoWeaver logo|
-
 It provides a simple layer of abstraction on top of
 `Biocypher <https://biocypher.org>`__, which remains responsible for
 doing the ontology alignment, supporting several graph database

--- a/make_doc.sh
+++ b/make_doc.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/sh
+sphinx-build -M html docs/ doc_built

--- a/make_doc.sh
+++ b/make_doc.sh
@@ -1,2 +1,2 @@
-#!/usr/bin/sh
+#!/usr/bin/env sh
 sphinx-build -M html docs/ doc_built

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ pandera = { version = "^0.22.1", extras = ["io"] }
 
 [tool.poetry.dev-dependencies]
 pytest = "^8.3.4"
+sphinx_rtd_theme = "^3.0.2"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
Adds fusion diagrams in the doc, and a way to build the doc locally.

To make the doc, just run `poetry run ./make_doc.sh`, then open `doc_built/html/index.html` in the browser, and click on the "Information fusion" section to see the new diagrams.