### PR TITLE
Output validation fixes.

### DIFF
--- a/src/ontoweaver/__init__.py
+++ b/src/ontoweaver/__init__.py
@@ -94,7 +94,7 @@ def read_file(filename, **kwargs):
     return read_funcs[ext](filename, **kwargs)
 
 
-def extract_reconciliate_write(biocypher_config_path, schema_path, filename_to_mapping = None, dataframe_to_mapping = None, parallel_mapping = 0, separator = None, affix = "none", affix_separator = ":", raise_errors = True, **kwargs):
+def extract_reconciliate_write(biocypher_config_path, schema_path, filename_to_mapping = None, dataframe_to_mapping = None, parallel_mapping = 0, separator = None, affix = "none", affix_separator = ":", validate_output = False, raise_errors = True, **kwargs):
     """Calls several mappings, each on the related Pandas-readable tabular data file,
        then reconciliate duplicated nodes and edges (on nodes' IDs, merging properties in lists),
        then export everything with BioCypher.
@@ -109,6 +109,7 @@ def extract_reconciliate_write(biocypher_config_path, schema_path, filename_to_m
            separator (str, optional): The separator to use for combining values in reconciliation. Defaults to None.
            affix (str, optional): The affix to use for type inclusion. Defaults to "none".
            affix_separator: The character(s) separating the label from its type affix. Defaults to ":".
+           validate_output: Whether to validate the output of the transformers. Defaults to False.
            raise_errors: Whether to raise errors encountered during the mapping, and stop the mapping process. Defaults to True.
            kwargs: A dictionary of arguments to pass to pandas.read_* functions.
 
@@ -134,6 +135,7 @@ def extract_reconciliate_write(biocypher_config_path, schema_path, filename_to_m
                 parallel_mapping=parallel_mapping,
                 affix=affix,
                 separator=affix_separator,
+                validate_output=validate_output,
                 raise_errors = raise_errors,
             )
 
@@ -149,6 +151,7 @@ def extract_reconciliate_write(biocypher_config_path, schema_path, filename_to_m
                 parallel_mapping=parallel_mapping,
                 affix=affix,
                 separator=affix_separator,
+                validate_output=validate_output,
                 raise_errors=raise_errors,
             )
 
@@ -171,7 +174,7 @@ def extract_reconciliate_write(biocypher_config_path, schema_path, filename_to_m
     return import_file
 
 
-def extract(filename_to_mapping = None, dataframe_to_mapping = None, parallel_mapping = 0, affix="none", affix_separator=":", raise_errors = True, **kwargs) -> Tuple[list[Tuple], list[Tuple]]:
+def extract(filename_to_mapping = None, dataframe_to_mapping = None, parallel_mapping = 0, affix="none", affix_separator=":", validate_output = False, raise_errors = True, **kwargs) -> Tuple[list[Tuple], list[Tuple]]:
     """
     Extracts nodes and edges from tabular data files based on provided mappings.
 
@@ -181,6 +184,7 @@ def extract(filename_to_mapping = None, dataframe_to_mapping = None, parallel_ma
         parallel_mapping (int): Number of workers to use in parallel mapping. Defaults to 0 for sequential processing.
         affix (str, optional): The affix to use for type inclusion. Defaults to "none".
         affix_separator: The character(s) separating the label from its type affix. Defaults to ":".
+        validate_output: Whether to validate the output of the transformers. Defaults to False.
         raise_errors: Whether to raise errors encountered during the mapping, and stop the mapping process. Defaults to True.
         kwargs: A dictionary of arguments to pass to pandas.read_* functions.
 
@@ -207,6 +211,7 @@ def extract(filename_to_mapping = None, dataframe_to_mapping = None, parallel_ma
                 parallel_mapping=parallel_mapping,
                 affix=affix,
                 separator=affix_separator,
+                validate_output=validate_output,
                 raise_errors = raise_errors,
             )
 
@@ -223,6 +228,7 @@ def extract(filename_to_mapping = None, dataframe_to_mapping = None, parallel_ma
                 parallel_mapping=parallel_mapping,
                 affix=affix,
                 separator=affix_separator,
+                validate_output=validate_output,
                 raise_errors=raise_errors,
             )
 

--- a/src/ontoweaver/ontoweave.py
+++ b/src/ontoweaver/ontoweave.py
@@ -137,6 +137,9 @@ def main():
     do.add_argument("-v", "--validate-only", action="store_true",
                     help="Only validate the given input data, do not apply the mapping.")
 
+    do.add_argument("-V", "--validate-output", action="store_true",
+                    help="Validate the output data against the mapping rules.")
+
     do.add_argument("-Ds", "--database-sep", metavar="CHARACTER",
         help="Character used to separate values in the database.")
 
@@ -169,6 +172,8 @@ def main():
     logger.info(f"    debug: `{asked.debug}`")
     logger.info(f"    log-level: `{asked.log_level}`")
     logger.info(f"    pass-errors: `{asked.pass_errors}`")
+    logger.info(f"    validate-only: `{asked.validate_only}`")
+    logger.info(f"    validate-output: `{asked.validate_output}`")
 
     logger.info(f"    asked mappings: `{asked.mapping}`")
     asked_mapping = []
@@ -239,6 +244,11 @@ def main():
         check_file(data_file)
         check_file(map_file)
 
+    if asked.validate_output:
+        validate_output = True
+    else:
+        validate_output = False
+
     logger.info(f"Running OntoWeaver...")
     if asked.debug:
         import_file = ontoweaver.extract_reconciliate_write(
@@ -249,6 +259,7 @@ def main():
             separator=asked.prop_sep,
             affix=asked.type_affix,
             affix_separator = asked.type_affix_sep,
+            validate_output = validate_output,
             raise_errors = not asked.pass_errors)
     else:
         try:
@@ -260,6 +271,7 @@ def main():
                 separator=asked.prop_sep,
                 affix=asked.type_affix,
                 affix_separator = asked.type_affix_sep,
+                validate_output = validate_output,
                 raise_errors = not asked.pass_errors)
         # Manage exceptions wih specific error codes:
         except ontoweaver.exceptions.ConfigError as e:

--- a/src/ontoweaver/validate.py
+++ b/src/ontoweaver/validate.py
@@ -157,3 +157,46 @@ class OutputValidator(Validator):
 
         # Update the validation rules
         self.validation_rules = pa.DataFrameSchema(merged_rules)
+
+class SimpleOutputValidator(Validator):
+
+    def __init__(self, validation_rules = None, raise_errors = True):
+        """Constructor for the SimpleValidator class. This class is used in case of absence of any validation rules outside
+        of checking for none-types and empty strings. The class is used to bypass the use of the Pandera package for validation,
+        which saves a lot of computational time when big datasets are used.
+
+        Args:
+            validation_rules: The schema used for validation.
+        """
+        super().__init__(validation_rules, raise_errors)
+
+    def __call__(self, val):
+        if pd.api.types.is_numeric_dtype(type(val)):
+            if math.isnan(val) or val == float("nan"):
+                return False
+
+        elif str(val).lower() == "nan" or val == "":
+            return False
+
+        return True
+
+class SkipValidator(Validator):
+    """Class used for skipping validation. This class is used to skip validation for specific transformers.
+    We implement the SkipValidator class in order to keep the validation logic in the same place as the other validators,
+    and keep the code in base.py uniform for all validation options."""
+
+    def __init__(self, validation_rules = None, raise_errors = True):
+        """Constructor for the SkipValidator class.
+
+        Args:
+            validation_rules: The schema used for validation.
+        """
+        super().__init__(validation_rules, raise_errors)
+
+    def __call__(self, val):
+
+        logger.info(f"Transformer output validation skipped. This could result in some empty or `nan` nodes in your knowledge graph."
+                    f" To enable output validation set validate_output to True.")
+
+        return True
+

--- a/tests/test_2_databases.py
+++ b/tests/test_2_databases.py
@@ -735,7 +735,7 @@ def test_2_databases():
     data_mapping = {f"tests/{directory_name2}/data.csv": f"tests/{directory_name2}/mapping.yaml",
                     f"tests/{directory_name1}/data.csv": f"tests/{directory_name1}/mapping.yaml"}
 
-    nodes, edges = ontoweaver.extract(filename_to_mapping=data_mapping, affix="suffix", raise_errors=False)
+    nodes, edges = ontoweaver.extract(filename_to_mapping=data_mapping, affix="suffix", validate_output=True, raise_errors=False)
 
     assert_node_set = testing_functions.convert_to_set(assert_nodes)
     f_node_set = testing_functions.convert_to_set(nodes)

--- a/tests/test_oncokb.py
+++ b/tests/test_oncokb.py
@@ -723,7 +723,7 @@ def test_oncokb():
 
     data_mapping = {f"tests/{directory_name}/data.csv": f"tests/{directory_name}/mapping.yaml"}
 
-    nodes, edges = ontoweaver.extract(filename_to_mapping=data_mapping, affix="suffix", raise_errors=False)
+    nodes, edges = ontoweaver.extract(filename_to_mapping=data_mapping, affix="suffix", validate_output=True, raise_errors=False)
 
     # The fusion functions is not being used due to the large number of duplicates, resulting in the properties being
     # fused in varying orders. This is not normally an issue, as the properties are still the same.

--- a/tests/test_output_validation.py
+++ b/tests/test_output_validation.py
@@ -21,7 +21,7 @@ def test_output_validation():
 
     data_mapping = {f"tests/{directory_name}/data.csv" : f"tests/{directory_name}/mapping.yaml" }
 
-    nodes, edges = ontoweaver.extract(filename_to_mapping=data_mapping, affix="suffix", raise_errors=False)
+    nodes, edges = ontoweaver.extract(filename_to_mapping=data_mapping, affix="suffix", validate_output=True, raise_errors=False)
 
     fnodes, fedges = ontoweaver.fusion.reconciliate(nodes, edges, separator=",")
 

--- a/tests/test_parallel_mapping.py
+++ b/tests/test_parallel_mapping.py
@@ -723,7 +723,7 @@ def test_oncokb():
 
     data_mapping = {f"tests/{directory_name}/data.csv": f"tests/{directory_name}/mapping.yaml"}
 
-    nodes, edges = ontoweaver.extract(filename_to_mapping=data_mapping, affix="suffix", parallel_mapping=8, raise_errors=False)
+    nodes, edges = ontoweaver.extract(filename_to_mapping=data_mapping, affix="suffix", parallel_mapping=8, validate_output=True, raise_errors=False)
 
     # The fusion functions is not being used due to the large number of duplicates, resulting in the properties being
     # fused in varying orders. This is not normally an issue, as the properties are still the same.


### PR DESCRIPTION
- Do not validate output by default.
- If `validate_output=True` and there is no output validation instructions in the mapping, use the previous logic of output validation with Pandas.
- If there is output validation rules defined, use Pandera.