### PR TITLE
refactor(loader): better pandas arguments handling + tests

### DIFF
--- a/src/ontoweaver/loader.py
+++ b/src/ontoweaver/loader.py
@@ -1,0 +1,175 @@
+import rdflib
+import pathlib
+import pandas as pd
+from abc import ABCMeta as ABSTRACT, abstractmethod
+
+from . import tabular
+
+class Loader(metaclass = ABSTRACT):
+    def __call__(self, data, **kwargs):
+        if self.allows(data):
+            return self.load(data, **kwargs)
+
+    @abstractmethod
+    def allows(self, data):
+        raise NotImplementedError()
+
+    @abstractmethod
+    def load(self, data, **kwargs):
+        raise NotImplementedError()
+
+    @abstractmethod
+    def adapter(self):
+        return NotImplementedError()
+
+
+class LoadPandasDataframe(Loader):
+    def allows(self, data):
+        return type(data) == pd.DataFrame
+
+    def load(self, df, **kwargs):
+        return df
+
+    def adapter(self):
+        return tabular.PandasAdapter
+
+class LoadPandasFile(Loader):
+    """Read a file with Pandas, using its extension to guess its format.
+
+    If no additional arguments are passed, it will call the
+    Pandas `read_*` function with `filter_na = False`, which makes empty cell
+    values to be loaded as empty strings instead of NaN values.
+
+    Args:
+        filename: The name of the data file the user wants to map.
+        separator (str, optional): The separator used in the data file. Defaults to None.
+        kwargs: A dictionary of arguments to pass to pandas.read_* functions.
+
+    Raises:
+        exception.FeatureError: if the extension is unknown.
+
+    Returns:
+        A Pandas DataFrame.
+    """
+
+    def __init__(self):
+            # We probably don't want NaN as a default,
+            # since they tend to end up in a label.
+            #'c' engine does not support regex separators (separators > 1 char and different
+            # from '\s+' are interpreted as regex) which results in an error.
+        self.read_funcs = {
+            '.csv'    : (pd.read_csv, {
+                "sep": ",",
+                'na_filter': True,
+                'engine': 'python'
+            }),
+            '.tsv'    : (pd.read_csv, {
+                "sep": "\t",
+                'na_filter': True,
+                'engine': 'python'
+            }),
+            '.txt'    : (pd.read_csv, {
+                'na_filter': True,
+                'engine': 'python'
+            }),
+            '.dat'    : (pd.read_csv, {
+                'na_filter': True,
+                'engine': 'python'
+            }),
+
+            '.xls'    : (pd.read_excel,   {'na_filter': True}),
+            '.xlsx'   : (pd.read_excel,   {'na_filter': True}),
+            '.xlsm'   : (pd.read_excel,   {'na_filter': True}),
+            '.xlsb'   : (pd.read_excel,   {'na_filter': True}),
+            '.odf'    : (pd.read_excel,   {'na_filter': True}),
+            '.ods'    : (pd.read_excel,   {'na_filter': True}),
+            '.odt'    : (pd.read_excel,   {'na_filter': True}),
+
+            '.json'   : (pd.read_json,    {'na_filter': True}),
+            '.html'   : (pd.read_html,    {'na_filter': True}),
+            '.xml'    : (pd.read_xml,     {'na_filter': True}),
+            '.hdf'    : (pd.read_hdf,     {'na_filter': True}),
+            '.feather': (pd.read_feather, {'na_filter': True}),
+            '.parquet': (pd.read_parquet, {'na_filter': True}),
+            '.pickle' : (pd.read_pickle,  {'na_filter': True}),
+            '.orc'    : (pd.read_orc,     {'na_filter': True}),
+            '.sas'    : (pd.read_sas,     {'na_filter': True}),
+            '.spss'   : (pd.read_spss,    {'na_filter': True}),
+            '.stata'  : (pd.read_stata,   {'na_filter': True}),
+        }
+
+
+    def allows(self, filename):
+        if type(filename) == str or type(filename) == pathlib.Path:
+            ext = pathlib.Path(filename).suffix 
+            if ext in self.read_funcs:
+                return True
+
+        return False
+
+
+    def load(self, filename, **kwargs):
+        ext = pathlib.Path(filename).suffix
+        if not self.allows(filename):
+            msg = f"File format '{ext}' of file '{filename}' is not supported (I can only read one of: {' ,'.join(self.read_funcs.keys())})"
+            logger.error(msg)
+            raise exceptions.FeatureError(msg)
+
+        f  = self.read_funcs[ext][0]
+        kw = self.read_funcs[ext][1]
+        # Overwrite default named arguments with the passed ones.
+        kw.update(kwargs)
+        return f(filename, **kw)
+
+
+    def adapter(self):
+        return tabular.PandasAdapter
+
+
+class LoadRDFGraph(Loader):
+    def allows(self, data):
+        return type(data) == rdflib.Graph
+
+    def load(self, g, **kwargs):
+        return g
+
+    def adapter(self):
+        return tabular.RDFAutoAdapter
+
+
+class LoadRDFFile(Loader):
+    def __init__(self):
+        self.allowed = [".owl", ".xml", ".n3", ".turtle", ".ttl", ".nt", ".trig", ".trix", ".json-ld"]
+
+    def allows(self, filename):
+        if type(filename) == str or type(filename) == pathlib.Path:
+            ext = pathlib.Path(filename).suffix
+            if ext in self.allowed:
+                return True
+
+        msg = f"File format '{ext}' of file '{filename}' is not supported (I can only read one of: {', '.join(self.allowed)})"
+        logger.warning(msg)
+        return False
+
+
+    def load(self, filename, **kwargs):
+        ext = pathlib.Path(filename).suffix
+        if not self.allows(filename):
+            msg = f"File format '{ext}' of file '{filename}' is not supported (I can only read one of: {' ,'.join(self.allowed)})"
+            logger.error(msg)
+            raise exceptions.FeatureError(msg)
+
+        g = rdflib.Graph()
+
+        if ext == ".owl":
+            g.parse(filename, format = "xml")
+        else:
+            g.parse(filename) # Guess the format based on extension.
+
+        return g
+
+
+    def adapter(self):
+        return tabular.OWLAutoAdapter
+
+

--- a/src/ontoweaver/ontoweave.py
+++ b/src/ontoweaver/ontoweave.py
@@ -143,8 +143,8 @@ def main():
     do.add_argument("-V", "--validate-output", action="store_true",
                     help="Validate the output data against the mapping rules.")
 
-    do.add_argument("-Ds", "--database-sep", metavar="CHARACTER",
-        help="Character used to separate values in the database.")
+    do.add_argument("-e", "--pandas-sep", metavar="CHARACTER",
+        help="Character used by the Pandas module to separate values in the input file database. [default: guessed from the extension]")
 
     do.add_argument("-D", "--debug", action="store_true",
         help=f"Run in debug mode. implies `--log-level DEBUG`, disables `--pass-errors`. NOTE: this will disable explicit return codes and show the call stack.")
@@ -253,6 +253,10 @@ def main():
     else:
         validate_output = False
 
+    kw = {}
+    if asked.pandas_sep:
+        kw = {"sep": asked.pandas_sep}
+
     logger.info(f"Running OntoWeaver...")
     if asked.debug:
         import_file = ontoweaver.weave(
@@ -264,7 +268,8 @@ def main():
             affix=asked.type_affix,
             type_affix_sep = asked.type_affix_sep,
             validate_output = validate_output,
-            raise_errors = not asked.pass_errors)
+            raise_errors = not asked.pass_errors,
+            **kw)
     else:
         try:
             import_file = ontoweaver.weave(
@@ -276,7 +281,8 @@ def main():
                 affix=asked.type_affix,
                 type_affix_sep = asked.type_affix_sep,
                 validate_output = validate_output,
-                raise_errors = not asked.pass_errors)
+                raise_errors = not asked.pass_errors,
+                **kw)
         # Manage exceptions wih specific error codes:
         except ontoweaver.exceptions.ConfigError as e:
             logger.error(f"ERROR in configuration: "+str(e))

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,0 +1,21 @@
+import rdflib
+import ontoweaver
+import pandas as pd
+
+def test_loader():
+    lpf = ontoweaver.loader.LoadPandasFile()
+    lpf.load("./tests/simplest/data.csv")
+    lpf.load("./tests/custom_transformer/data.tsv")
+
+    data = [1,2,3]
+    df = pd.DataFrame(data)
+    lpd = ontoweaver.loader.LoadPandasDataframe()
+    lpd.load(df)
+
+    lrf = ontoweaver.loader.LoadRDFFile()
+    lrf.load("./tests/test_preprocessing_ontology/OIM_test_preprocessing.owl")
+
+    g = rdflib.Graph()
+    g.parse("./tests/test_preprocessing_ontology/bc_OIM_test_preprocessing.owl")
+    lrg = ontoweaver.loader.LoadRDFGraph()
+    lrg.load(g)


### PR DESCRIPTION
- Move loaders from init to their own module.
- Adds loaders tests.
- Propagate named arguments from ontoweave.
- BREAKING CHANGE: rename -Ds to -e and --database-sep to --pandas-sep.

Refs: fixes #141