### PR TITLE
fix: Python 3.11-compatible typing.override import

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "pyaml>=25.7.0",
     "fastparquet>=2025.12.0",
     "csvkit>=2.2.0",
+    "typing_extensions>=4.0.0",
 ]
 
 [dependency-groups]

--- a/src/ontoweaver/make_labels.py
+++ b/src/ontoweaver/make_labels.py
@@ -3,7 +3,7 @@
 import logging
 import abc
 import re
-from typing import override
+from typing_extensions import override
 from abc import ABCMeta as ABSTRACT, abstractmethod
 
 from . import errormanager, exceptions
@@ -160,4 +160,3 @@ class MultiTypeOnColumnLabelMaker(MultiTypeLabelMakerInterface):
     @override
     def get_value_from(self, value: str, row: list) -> str:
         return str(row[self.match_type_from_column])
-


### PR DESCRIPTION
## Summary

Fixes CI test collection on Python 3.11: 	yping.override is only available on 3.12+.

- Import override from 	yping_extensions
- Add 	yping_extensions dependency

## Verify

Reproduced CI ImportError: cannot import name 'override' from 'typing' and confirmed import succeeds after the change (Python 3.11-compat check).

## Notes

Minimal fix only — no workflow YAML edits.
---
*This change was made by **kramlip code-agent** (verify-gated CI repair — customer-hosted / BYO LLM).*

**Contact / docs**
- Email: [cluevion@gmail.com](mailto:cluevion@gmail.com)
- Site: [https://kramlipi.com](https://kramlipi.com)
- Docs: [https://kramlipi.github.io](https://kramlipi.github.io)

Co-authored-by: kramlip ai-code-agent <ai-code-agent@users.noreply.github.com>